### PR TITLE
fix: keep private pnpm pins out of the consumer overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Older repository history is available in git.
 
 ### Fixed
 
+- Keep OpenClaw's private pnpm pins under `openclawPackages` so the default overlay no longer replaces Nixpkgs' pnpm for unrelated packages. Thanks @jerome-benoit (#116).
 - `openclaw-reload` now restarts the configured Home Manager launchd labels or
   systemd user units instead of the old hardcoded `.nix` and `.nix-test`
   labels.

--- a/README.md
+++ b/README.md
@@ -1050,6 +1050,10 @@ home-manager switch --rollback  # revert
 | `openclaw-gateway` | Component output: gateway CLI/service only |
 | `openclaw-app` | Component output: macOS app only |
 
+The default overlay preserves Nixpkgs' `pnpm` and versioned pnpm attributes.
+OpenClaw's private pnpm pins are available as `pkgs.openclawPackages.pnpm_11`
+and `pkgs.openclawPackages.pnpm_12` when needed for packaging or debugging.
+
 ### Local memory
 
 QMD is the supported local memory backend when OpenClaw config opts into it. The default `openclaw` package does not build or install QMD unless `memory.backend = "qmd"` is set. Linux uses upstream `tobi/qmd`; Darwin uses the repaired `nix-openclaw-tools` package until upstream QMD is fixed there.

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,9 @@
           let
             stableChecks = {
               gateway = packageSetStable.openclaw-gateway;
+              overlay = pkgs.callPackage ./nix/checks/openclaw-overlay.nix {
+                inherit nixpkgs system overlay;
+              };
               bin-surface = pkgs.callPackage ./nix/checks/openclaw-bin-surface.nix {
                 openclawPackage = packageSetStable.openclaw;
               };
@@ -183,6 +186,7 @@
               module-render = pkgs.symlinkJoin {
                 name = "openclaw-module-render";
                 paths = [
+                  stableChecks.overlay
                   stableChecks.default-instance
                   stableChecks.source-override-render
                   stableChecks.workspace-materializer

--- a/nix/checks/openclaw-overlay.nix
+++ b/nix/checks/openclaw-overlay.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenvNoCC,
+  nixpkgs,
+  system,
+  overlay,
+}:
+
+let
+  base = import nixpkgs { inherit system; };
+  overlaid = import nixpkgs {
+    inherit system;
+    overlays = [ overlay ];
+  };
+  privateNames = [
+    "pnpm_11"
+    "pnpm_12"
+  ];
+  pnpmNames = [
+    "pnpm"
+    "pnpm_10"
+  ] ++ privateNames;
+  unchanged =
+    name:
+    builtins.hasAttr name base == builtins.hasAttr name overlaid
+    && (!(builtins.hasAttr name base) || base.${name}.drvPath == overlaid.${name}.drvPath);
+  privatePackages = import ../packages { pkgs = base; };
+  namespaced =
+    name:
+    overlaid.openclawPackages.${name}.drvPath == privatePackages.${name}.drvPath
+    && (overlaid.openclawPackages.withTools { }).${name}.drvPath == privatePackages.${name}.drvPath;
+in
+assert lib.assertMsg (lib.all unchanged pnpmNames)
+  "The OpenClaw overlay must not change consumer pnpm attributes.";
+assert lib.assertMsg (lib.all namespaced privateNames)
+  "Private pnpm packages must remain available under openclawPackages and withTools.";
+stdenvNoCC.mkDerivation {
+  name = "openclaw-overlay";
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = "${../scripts/empty-install.sh}";
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -31,7 +31,10 @@ let
       inherit toolNamesOverride excludeToolNames;
     };
 in
-packages
+(builtins.removeAttrs packages [
+  "pnpm_11"
+  "pnpm_12"
+])
 // {
   openclawPackages = packages // {
     inherit toolNames withTools;


### PR DESCRIPTION
Applying the default overlay currently exports OpenClaw's private `pnpm_11` and `pnpm_12` into the consumer's Nixpkgs set. With the Nixpkgs revision in #116, that changes unrelated packages from pnpm 11.22.0 to 11.2.2 before any OpenClaw package is built.

Filter those two attributes at the overlay boundary. Keep the private pins available through `openclawPackages`, `openclawPackages.withTools`, and the existing flake package outputs. Document the namespace and add a regression check to the Linux and Darwin `module-render` CI groups.

Fixes #116. Thanks @jerome-benoit for the reproduction.

Validation on x86_64 Linux with Nix 2.35.2:

- Imported Nixpkgs `e8be7818e19ada32105a8af937a6a473b38167ca` with and without the actual default overlay. Before: `11.22.0 -> 11.2.2`, different `drvPath`; after: `11.22.0 -> 11.22.0`, identical `drvPath`.
- Built the overlaid consumer's `pnpm` with `nix build --impure --no-link --print-out-paths --expr '(import /tmp/openclaw-consumer.nix).overlaid.pnpm'` and ran the returned `bin/pnpm --version`: `11.2.2` before, `11.22.0` after.
- The new `checks.x86_64-linux.overlay` failed before the fix with `The OpenClaw overlay must not change consumer pnpm attributes.` It builds successfully after the fix. Its assertions compare attribute presence and derivation paths, and verify both private versions remain namespaced.
- `nix build --no-link .#checks.x86_64-linux.module-render` passed, including source-override rendering.
- `nix eval --raw .#checks.aarch64-darwin.overlay.drvPath` and `nix eval --raw .#checks.aarch64-darwin.default-instance.drvPath` passed. Both platforms still expose private pnpm versions 11.2.2 and 12.1.0 through flake packages.
- `nix flake show --accept-flake-config`, flake-lock provenance, release-selector tests, updater shell syntax, workflow YAML parsing, and `git diff --check` passed.
- Codex Autoreview: scoped-clean at its default P0 threshold.

The local Garnix cache lookup had a DNS failure; Nix used the NixOS cache and built the remaining checks successfully. Full Linux/macOS supported-surface checks run through the PR's existing CI workflow.

### Real behavior proof on the changed overlay

This is executed after-change evidence, not an evaluation-only test plan. Both `nix build` commands produced real packages, and their `bin/pnpm` executables were run. Before uses main `3e11847037b15a13829eab924970a8815a298687`; after uses PR head `4acbee65db0dcf47fbf811a53cd75ae81e634661`.

From each checkout, create the consumer expression:

```sh
cat > /tmp/openclaw-consumer.nix <<'NIX'
let
  flake = builtins.getFlake (builtins.getEnv "PWD");
  nixpkgs = builtins.getFlake "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca";
  base = import nixpkgs.outPath { system = "x86_64-linux"; };
  overlaid = import nixpkgs.outPath {
    system = "x86_64-linux";
    overlays = [ flake.overlays.default ];
  };
in { inherit base overlaid; }
NIX
nix eval --impure --json --expr 'let p = import /tmp/openclaw-consumer.nix; in { base = p.base.pnpm.version; overlaid = p.overlaid.pnpm.version; sameDerivation = p.base.pnpm.drvPath == p.overlaid.pnpm.drvPath; }'
consumer_pnpm=$(nix build --impure --no-link --print-out-paths --expr '(import /tmp/openclaw-consumer.nix).overlaid.pnpm')
"$consumer_pnpm/bin/pnpm" --version
```

The proof environment used `/workspace` as the checkout path in `builtins.getFlake`; the command above uses the invoking checkout's `PWD` for portability. Nix's `nix-command` and `flakes` experimental features were enabled.

Observed before:

```text
{"base":"11.22.0","overlaid":"11.2.2","sameDerivation":false}
11.2.2
```

Observed after:

```text
{"base":"11.22.0","overlaid":"11.22.0","sameDerivation":true}
11.22.0
```

The regression was separately run against the original overlay and failed with the expected assertion, then passed after the fix. Private flake package outputs after the fix:

```json
{"aarch64-darwin":{"pnpm_11":"11.2.2","pnpm_12":"12.1.0"},"x86_64-linux":{"pnpm_11":"11.2.2","pnpm_12":"12.1.0"}}
```

Compatibility: users who intentionally relied on the accidental top-level OpenClaw pins should use `pkgs.openclawPackages.pnpm_11` / `.pnpm_12`. The README documents those paths. Restoring the consumer's Nixpkgs attributes is the intended bug fix; other overlay exports are unchanged.
