### PR TITLE
build: refresh private pnpm tools and fix the Linux runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Older repository history is available in git.
 
 ### Fixed
 
+- Patch the native pnpm 12 Linux executable to use the Nix loader and runtime libraries, so its public package output runs inside the Nix sandbox.
 - Constrain workspace activation cleanup and replacement to configured workspace roots, preserve stale paths from removed or moved instances with a warning, and avoid changing symlink targets or hardlinked file permissions during cleanup. Create home-relative workspace paths containing spaces correctly during activation. Thanks @SebTardif (#119).
 
 ## 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Older repository history is available in git.
 
 ## 2026-09-04
 
+### Changed
+
+- Update the private pnpm 11 and 12 tools to 11.25.0 and 12.3.1, with Linux/macOS checks for offline installs and frozen lockfiles. Keep the existing Node.js 22 runtime and Nixpkgs overlay boundary.
+
 ### Fixed
 
 - Constrain workspace activation cleanup and replacement to configured workspace roots, preserve stale paths from removed or moved instances with a warning, and avoid changing symlink targets or hardlinked file permissions during cleanup. Create home-relative workspace paths containing spaces correctly during activation. Thanks @SebTardif (#119).

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,9 @@
                 includeSourceOverrideChecks = true;
               };
               workspace-materializer = pkgs.callPackage ./nix/checks/openclaw-workspace-materializer.nix { };
+              pnpm-runtime = pkgs.callPackage ./nix/checks/openclaw-pnpm-runtime.nix {
+                inherit (packageSetStable) pnpm_11 pnpm_12;
+              };
               config-validity = pkgs.callPackage ./nix/checks/openclaw-config-validity.nix {
                 openclawGateway = packageSetStable.openclaw-gateway;
                 includeRuntimePluginSmoke = false;
@@ -171,6 +174,7 @@
                 packageSetStable.openclaw-gateway
                 stableChecks.bin-surface
                 stableChecks.package-contents
+                stableChecks.pnpm-runtime
               ]
               ++ pkgs.lib.optionals (packageSetStable ? openclaw-app && packageSetStable.openclaw-app != null) [
                 packageSetStable.openclaw-app

--- a/maintainers/gates.md
+++ b/maintainers/gates.md
@@ -6,6 +6,7 @@ Use targeted checks while debugging, then run the full relevant gate before hand
 
 - `scripts/check-flake-lock-owners.sh`
 - selector tests
+- Private pnpm runtime check (`checks.<system>.pnpm-runtime`, included in `package-artifacts`): offline local-tarball install, package execution, and frozen-lockfile rejection for both supported private pnpm majors
 - updater shell syntax
 - workflow YAML parse
 - `nix flake show --accept-flake-config`

--- a/nix/checks/openclaw-pnpm-runtime.nix
+++ b/nix/checks/openclaw-pnpm-runtime.nix
@@ -1,0 +1,26 @@
+{
+  stdenvNoCC,
+  nodejs_22,
+  pnpm_11,
+  pnpm_12,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "openclaw-pnpm-runtime";
+  version = "1";
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ nodejs_22 ];
+
+  env = {
+    PNPM_11_PACKAGE = pnpm_11;
+    PNPM_12_PACKAGE = pnpm_12;
+  };
+
+  doCheck = true;
+  checkPhase = "${../scripts/check-openclaw-pnpm-runtime.sh}";
+  installPhase = "${../scripts/empty-install.sh}";
+}

--- a/nix/packages/pnpm-11.nix
+++ b/nix/packages/pnpm-11.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
-  version = "11.2.2";
+  version = "11.25.0";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
-    hash = "sha256-mcS+gx7SMYKYlRQtlnk9vnWvxTeVkzrtg2bmjczh4bg=";
+    hash = "sha256-M90HSPJ+eRbE8ci2lDRhmD40U7BrvaYxKmKAEwtIgeU=";
   };
 
   preConfigure = ''

--- a/nix/packages/pnpm-12.nix
+++ b/nix/packages/pnpm-12.nix
@@ -10,11 +10,11 @@ let
     {
       aarch64-darwin = {
         package = "exe.darwin-arm64";
-        hash = "sha256-Qu/s8ydbt1gZMsY20LODsSRJBYWnKUM0C/jBh8OFcKE=";
+        hash = "sha256-Y2JE8yGVuxL5svKHd7cZDvD7wJzs0ciUrylUw5GeZh4=";
       };
       x86_64-linux = {
         package = "exe.linux-x64";
-        hash = "sha256-qiizYKMCcFxd18YQTrQsDExEgMnghoYiCgiU+iIh+2w=";
+        hash = "sha256-ay8FtfwPEhyDBJlO5/tdKAH/7uNBDb2Zze2C8wbw2io=";
       };
     }
     .${stdenvNoCC.hostPlatform.system}
@@ -22,7 +22,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
-  version = "12.1.0";
+  version = "12.3.1";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/@pnpm/${platformSource.package}/-/${platformSource.package}-${finalAttrs.version}.tgz";

--- a/nix/packages/pnpm-12.nix
+++ b/nix/packages/pnpm-12.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  stdenv,
   stdenvNoCC,
+  autoPatchelfHook,
   fetchurl,
   nodejs_22,
 }:
@@ -28,6 +30,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     url = "https://registry.npmjs.org/@pnpm/${platformSource.package}/-/${platformSource.package}-${finalAttrs.version}.tgz";
     hash = platformSource.hash;
   };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
 
   installPhase = ''
     runHook preInstall

--- a/nix/scripts/check-openclaw-pnpm-runtime.sh
+++ b/nix/scripts/check-openclaw-pnpm-runtime.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+for pnpm_package in "$PNPM_11_PACKAGE" "$PNPM_12_PACKAGE"; do
+  pnpm="$pnpm_package/bin/pnpm"
+  version="$("$pnpm" --version)"
+  major="${version%%.*}"
+  project="$tmp_dir/pnpm-$major/project with spaces"
+  export HOME="$tmp_dir/pnpm-$major/home"
+  export XDG_CONFIG_HOME="$HOME/config"
+  export XDG_CACHE_HOME="$HOME/cache"
+  export XDG_DATA_HOME="$HOME/data"
+  mkdir -p "$project/package" "$HOME"
+
+  cat > "$project/package/package.json" <<'JSON'
+{"name":"openclaw-pnpm-fixture","version":"1.0.0","main":"index.js"}
+JSON
+  printf '%s\n' 'module.exports = "offline-install-ok";' > "$project/package/index.js"
+  COPYFILE_DISABLE=1 tar -czf "$project/fixture.tgz" -C "$project" package
+  cat > "$project/package.json" <<JSON
+{"private":true,"packageManager":"pnpm@$major.99.99","dependencies":{"openclaw-pnpm-fixture":"file:fixture.tgz"}}
+JSON
+
+  (
+    cd "$project"
+    "$pnpm" install --lockfile-only --offline --ignore-scripts
+    cp pnpm-lock.yaml expected-lock.yaml
+    PNPM_CONFIG_OFFLINE=true "$pnpm" fetch
+    "$pnpm" install --frozen-lockfile --offline --ignore-scripts
+    "$pnpm" exec node -e 'if (require("openclaw-pnpm-fixture") !== "offline-install-ok") process.exit(1)'
+    cmp expected-lock.yaml pnpm-lock.yaml
+
+    node -e 'const fs = require("node:fs"); const p = JSON.parse(fs.readFileSync("package.json")); p.dependencies["missing-from-lock"] = "1.0.0"; fs.writeFileSync("package.json", JSON.stringify(p));'
+    if "$pnpm" install --frozen-lockfile --offline --ignore-scripts > frozen-failure.log 2>&1; then
+      echo "pnpm $version accepted a manifest that disagrees with its frozen lockfile" >&2
+      exit 1
+    fi
+    grep -q 'ERR_PNPM_OUTDATED_LOCKFILE' frozen-failure.log
+    cmp expected-lock.yaml pnpm-lock.yaml
+  )
+  echo "pnpm $version: offline install, execution, and frozen-lockfile rejection passed"
+done

--- a/nix/scripts/gateway-smoke.mjs
+++ b/nix/scripts/gateway-smoke.mjs
@@ -71,6 +71,8 @@ function isolatedEnv() {
     OPENCLAW_STATE_DIR: path.join(tmpDir, "state"),
     OPENCLAW_LOG_DIR: path.join(tmpDir, "logs"),
     OPENCLAW_NIX_MODE: "1",
+    // Loopback health probes must not advertise shared CI runner hostnames on the LAN.
+    OPENCLAW_DISABLE_BONJOUR: "1",
     NO_COLOR: "1",
   };
 


### PR DESCRIPTION
Refresh the private pnpm tools from 11.2.2 to 11.25.0 and from 12.1.0 to 12.3.1, and repair the native pnpm 12 Linux package. Both tools retain their existing major families, Node.js 22, and the private Nixpkgs overlay boundary. The three npm artifacts were checked against their registry integrity values before calculating the Nix hashes.

The new package check exposed a pre-existing Linux defect: both the old and refreshed native pnpm 12 executables request `/lib64/ld-linux-x86-64.so.2` and shared runtime libraries that are absent at those paths in the Nix sandbox. Linux-only `autoPatchelfHook` and the compiler runtime library input resolve the interpreter and dependencies to Nix store paths. The existing install check still requires the packaged command to run successfully.

The runtime check runs both packaged pnpm outputs in the Linux and macOS `package-artifacts` gate. In an isolated home and a project path containing spaces, it installs a local tarball offline, executes the installed module, verifies an unchanged frozen lockfile, and requires `ERR_PNPM_OUTDATED_LOCKFILE` after a manifest-only dependency change. An unavailable same-major project pin also exercises the existing Nix-managed package-manager version behavior.

Validation: local artifact smoke tests passed for both versions; pnpm 11 used host Node.js 26 for that supplemental run. Flake input provenance, JavaScript contract tests, shell syntax, workflow YAML parsing, and diff checks passed. The complete candidate passed isolated P0–P2 review. The first Linux Nix run caught the loader defect above. The first macOS run separately failed when Bonjour conflict renaming exceeded the DNS label limit on the hosted runner. The loopback smoke fixture now sets the supported OPENCLAW_DISABLE_BONJOUR override only in its isolated environment; actual startup, authenticated health, and plugin-loading assertions are unchanged. Final-head [CI passed](https://github.com/openclaw/nix-openclaw/actions/runs/33861115352) at `734b13849097e99ab09b662eedd8173685a46181`: [Linux](https://github.com/openclaw/nix-openclaw/actions/runs/33861115352/job/100986475382) and [macOS](https://github.com/openclaw/nix-openclaw/actions/runs/33861115352/job/100986475330) both built and ran the packaged Node.js 22/pnpm runtime check, passed all supported-surface gates, and verified Home Manager or launchd activation. [CodeQL passed](https://github.com/openclaw/nix-openclaw/actions/runs/33861111683). The exact committed candidate also passed a fresh isolated P0–P2 preland review with no actionable findings. The supplemental remote proof attempt never executed; the package proof above comes from CI.

OpenClaw, QMD, and flake input pins are unchanged. The existing upstream promotion blocker remains: the supported acpx artifact lacks shrinkwrap or bundled runtime dependencies. This PR preserves that deterministic packaging requirement and the immutable-skill contract.
