### PR TITLE
fix: preserve spaced Home Manager config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Older repository history is available in git.
 
 ## Unreleased
 
-- Fix Home Manager config symlink activation for paths containing spaces, while preserving home-relative `~/` destinations; thanks @SebTardif (#122).
+- Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
 
 ## 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog starts with the current pre-1.0 nix-openclaw Home Manager module
 API transition.
 Older repository history is available in git.
 
+## Unreleased
+
+- Fix Home Manager config symlink activation for paths containing spaces, while preserving home-relative `~/` destinations; thanks @SebTardif (#122).
+
 ## 2026-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Use named instances when you need two local gateways. Keep the default package u
 Config activation supports paths containing spaces, including a custom
 `instances.<name>.configPath`. A leading `~/` is resolved against the configured
 Home Manager home directory before the config symlink is created.
+Systemd environment entries preserve spaces in the config and state paths.
 
 ```nix
 programs.openclaw = {

--- a/README.md
+++ b/README.md
@@ -908,6 +908,10 @@ Uses `instances.default` to unlock per-group mention rules. If `instances` is se
 
 Use named instances when you need two local gateways. Keep the default package unless you are actively debugging a local gateway checkout.
 
+Config activation supports paths containing spaces, including a custom
+`instances.<name>.configPath`. A leading `~/` is resolved against the configured
+Home Manager home directory before the config symlink is created.
+
 ```nix
 programs.openclaw = {
   workspace = {

--- a/nix/checks/openclaw-default-instance.nix
+++ b/nix/checks/openclaw-default-instance.nix
@@ -183,16 +183,16 @@ let
       "ok";
 
   spacedConfigEval = moduleEval {
-    instances.default.configPath = "/tmp/openclaw state/config file.json";
+    instances.default.configPath = "/tmp/openclaw state/config 'file'.json";
   };
   spacedConfigEnvironmentCheck =
     if
       pkgs.stdenv.hostPlatform.isLinux
-      && !(lib.elem "'OPENCLAW_CONFIG_PATH=/tmp/openclaw state/config file.json'"
+      && !(lib.elem "\"OPENCLAW_CONFIG_PATH=/tmp/openclaw state/config 'file'.json\""
         spacedConfigEval.config.systemd.user.services.openclaw-gateway.Service.Environment
       )
     then
-      throw "Systemd config environment must preserve paths containing spaces."
+      throw "Systemd config environment must preserve paths containing spaces and quotes."
     else
       "ok";
 

--- a/nix/checks/openclaw-default-instance.nix
+++ b/nix/checks/openclaw-default-instance.nix
@@ -182,6 +182,20 @@ let
     else
       "ok";
 
+  spacedConfigEval = moduleEval {
+    instances.default.configPath = "/tmp/openclaw state/config file.json";
+  };
+  spacedConfigEnvironmentCheck =
+    if
+      pkgs.stdenv.hostPlatform.isLinux
+      && !(lib.elem "'OPENCLAW_CONFIG_PATH=/tmp/openclaw state/config file.json'"
+        spacedConfigEval.config.systemd.user.services.openclaw-gateway.Service.Environment
+      )
+    then
+      throw "Systemd config environment must preserve paths containing spaces."
+    else
+      "ok";
+
   reloadHelperText =
     eval:
     let
@@ -993,6 +1007,7 @@ let
     [
       defaultCheck
       homeRelativeConfigCheck
+      spacedConfigEnvironmentCheck
       reloadDefaultCheck
       reloadNamedCheck
       reloadCustomDefaultCheck

--- a/nix/checks/openclaw-default-instance.nix
+++ b/nix/checks/openclaw-default-instance.nix
@@ -170,6 +170,18 @@ let
       "ok"
   );
 
+  homeRelativeConfigEval = moduleEval {
+    instances.default.stateDir = "~/openclaw state";
+  };
+  homeRelativeConfigCheck =
+    let
+      activation = homeRelativeConfigEval.config.home.activation.openclawConfigFiles.data;
+    in
+    if !(lib.hasInfix " '/tmp/openclaw state/openclaw.json'" activation) then
+      throw "Config activation must resolve home-relative paths before shell escaping."
+    else
+      "ok";
+
   reloadHelperText =
     eval:
     let
@@ -980,6 +992,7 @@ let
   checkKey = builtins.deepSeq (
     [
       defaultCheck
+      homeRelativeConfigCheck
       reloadDefaultCheck
       reloadNamedCheck
       reloadCustomDefaultCheck

--- a/nix/checks/openclaw-hm-activation.nix
+++ b/nix/checks/openclaw-hm-activation.nix
@@ -56,6 +56,7 @@ pkgs.testers.nixosTest {
               installApp = false;
               launchd.enable = false;
               instances.default = {
+                configPath = "/home/alice/.openclaw/config with spaces.json";
                 workspaceDir = "~/custom workspace";
                 gatewayPort = 18999;
                 config = {

--- a/nix/checks/openclaw-hm-activation.nix
+++ b/nix/checks/openclaw-hm-activation.nix
@@ -56,7 +56,7 @@ pkgs.testers.nixosTest {
               installApp = false;
               launchd.enable = false;
               instances.default = {
-                configPath = "/home/alice/.openclaw/config with spaces.json";
+                configPath = "/home/alice/.openclaw/config with spaces and 'quotes'.json";
                 workspaceDir = "~/custom workspace";
                 gatewayPort = 18999;
                 config = {

--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -360,7 +360,8 @@ let
             WorkingDirectory = inst.stateDir;
             Restart = "always";
             RestartSec = "1s";
-            Environment = map lib.escapeShellArg [
+            # Systemd needs whole quoted items, not shell quote concatenation.
+            Environment = map builtins.toJSON [
               "HOME=${homeDir}"
               "OPENCLAW_CONFIG_PATH=${inst.configPath}"
               "OPENCLAW_STATE_DIR=${inst.stateDir}"

--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -519,7 +519,8 @@ in
     home.activation.openclawConfigFiles = lib.hm.dag.entryAfter [ "openclawDirs" ] ''
       ${lib.concatStringsSep "\n" (
         map (
-          item: "run --quiet ${lib.getExe' pkgs.coreutils "ln"} -sfn ${item.configFile} ${item.configPath}"
+          item:
+          "run --quiet ${lib.getExe' pkgs.coreutils "ln"} -sfn ${lib.escapeShellArg item.configFile} ${lib.escapeShellArg (openclawLib.resolvePath item.configPath)}"
         ) instanceConfigs
       )}
     '';

--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -360,7 +360,7 @@ let
             WorkingDirectory = inst.stateDir;
             Restart = "always";
             RestartSec = "1s";
-            Environment = [
+            Environment = map lib.escapeShellArg [
               "HOME=${homeDir}"
               "OPENCLAW_CONFIG_PATH=${inst.configPath}"
               "OPENCLAW_STATE_DIR=${inst.stateDir}"

--- a/nix/tests/hm-activation-macos/home.nix
+++ b/nix/tests/hm-activation-macos/home.nix
@@ -19,7 +19,7 @@
     runtimePackages = [ pkgs.jq ];
     environment.OPENCLAW_TEST_SECRET = "/tmp/openclaw-secret";
     instances.default = {
-      configPath = "/tmp/hm-activation-home/.openclaw/config with spaces.json";
+      configPath = "/tmp/hm-activation-home/.openclaw/config with spaces and 'quotes'.json";
       workspaceDir = "~/custom workspace";
       gatewayPort = 18999;
       logPath = "/tmp/hm-activation-home/.openclaw/openclaw-gateway.log";

--- a/nix/tests/hm-activation-macos/home.nix
+++ b/nix/tests/hm-activation-macos/home.nix
@@ -19,6 +19,7 @@
     runtimePackages = [ pkgs.jq ];
     environment.OPENCLAW_TEST_SECRET = "/tmp/openclaw-secret";
     instances.default = {
+      configPath = "/tmp/hm-activation-home/.openclaw/config with spaces.json";
       workspaceDir = "~/custom workspace";
       gatewayPort = 18999;
       logPath = "/tmp/hm-activation-home/.openclaw/openclaw-gateway.log";

--- a/nix/tests/hm-activation.py
+++ b/nix/tests/hm-activation.py
@@ -5,7 +5,9 @@ machine.wait_until_succeeds(
     "systemctl show -p SubState home-manager-alice.service | grep -Eq '^SubState=(dead|exited)$'"
 )
 
-machine.wait_until_succeeds("test -f /home/alice/.openclaw/openclaw.json")
+config_path = "'/home/alice/.openclaw/config with spaces.json'"
+machine.wait_until_succeeds(f"test -f {config_path}")
+machine.succeed(f"test -L {config_path}")
 workspace = "'/home/alice/custom workspace'"
 machine.wait_until_succeeds(f"test -f {workspace}/AGENTS.md")
 machine.succeed(f"test ! -L {workspace}/AGENTS.md")
@@ -13,7 +15,7 @@ machine.succeed(f"test -f {workspace}/IDENTITY.md")
 machine.succeed(f"test -f {workspace}/USER.md")
 machine.succeed(f"test -f {workspace}/HEARTBEAT.md")
 machine.succeed(f"test -f {workspace}/LORE.md")
-machine.succeed("grep -q '\"skipBootstrap\":true' /home/alice/.openclaw/openclaw.json")
+machine.succeed(f"grep -q '\"skipBootstrap\":true' {config_path}")
 machine.succeed(f"grep -q 'BEGIN NIX-REPORT' {workspace}/TOOLS.md")
 machine.wait_until_succeeds(
     "test -x /home/alice/.openclaw/agents/main/agent/codex-home/home/.nix-profile/bin/jq"

--- a/nix/tests/hm-activation.py
+++ b/nix/tests/hm-activation.py
@@ -1,3 +1,5 @@
+import shlex
+
 start_all()
 
 machine.wait_until_succeeds(
@@ -5,7 +7,7 @@ machine.wait_until_succeeds(
     "systemctl show -p SubState home-manager-alice.service | grep -Eq '^SubState=(dead|exited)$'"
 )
 
-config_path = "'/home/alice/.openclaw/config with spaces.json'"
+config_path = shlex.quote("/home/alice/.openclaw/config with spaces and 'quotes'.json")
 machine.wait_until_succeeds(f"test -f {config_path}")
 machine.succeed(f"test -L {config_path}")
 workspace = "'/home/alice/custom workspace'"

--- a/scripts/hm-activation-macos.sh
+++ b/scripts/hm-activation-macos.sh
@@ -41,7 +41,8 @@ fi
 test ! -e "$HOME/custom workspace"
 "$activation_package/activate"
 
-test -f "$HOME/.openclaw/openclaw.json"
+test -f "$HOME/.openclaw/config with spaces.json"
+test -L "$HOME/.openclaw/config with spaces.json"
 test -f "$HOME/custom workspace/LORE.md"
 test ! -L "$HOME/custom workspace/LORE.md"
 test -f "$plist"

--- a/scripts/hm-activation-macos.sh
+++ b/scripts/hm-activation-macos.sh
@@ -41,8 +41,8 @@ fi
 test ! -e "$HOME/custom workspace"
 "$activation_package/activate"
 
-test -f "$HOME/.openclaw/config with spaces.json"
-test -L "$HOME/.openclaw/config with spaces.json"
+test -f "$HOME/.openclaw/config with spaces and 'quotes'.json"
+test -L "$HOME/.openclaw/config with spaces and 'quotes'.json"
 test -f "$HOME/custom workspace/LORE.md"
 test ! -L "$HOME/custom workspace/LORE.md"
 test -f "$plist"


### PR DESCRIPTION
Home Manager activation split config destinations containing spaces into multiple `ln` arguments. On Linux, raw systemd environment entries also split the path, so the gateway could not read the generated config even after its symlink was repaired.

Resolve `~/` against the configured home directory before shell-escaping both symlink operands. Encode each systemd environment assignment as a whole double-quoted item with C-style escapes; POSIX quote concatenation would break apostrophes. The Linux VM and macOS launchd fixtures use a real filename containing spaces and apostrophes, verify the symlink, and start the built gateway. Module evaluation covers home-relative resolution and service-environment quoting.

Fixes #122. Thanks @SebTardif for the report and initial fix; contributor credit is preserved in the commit and changelog.

Behavior proof for `7dc0777bb8c589ce7859f33aafc062f3431c4585`:

- The original unquoted `ln` command failed against a synthetic config destination containing spaces; the quoted command also preserved apostrophes, created the correct symlink and succeeded on a second application.
- The Linux NixOS VM ran real Home Manager activation, verified the generated `config with spaces and 'quotes'.json` symlink and its content, then started the built gateway under systemd and waited for port 18999.
- macOS ran real Home Manager activation, verified the spaced config symlink, started the built gateway under launchd, and required a successful JSON gateway-health response.
- Both platforms also passed the complete supported package, module, runtime, activation, runtime-plugin, and QMD proof groups.

CI: https://github.com/openclaw/nix-openclaw/actions/runs/33985867466

Local JavaScript contracts: 9 passed. Flake provenance, shell syntax, workflow YAML, and Python fixture syntax passed. Both local-candidate and committed-branch independent reviews completed with no actionable P0–P2 findings. Contributor credit is preserved in the commit and changelog.

The successful Linux VM runtime summary recorded the config symlink check, a 24.9-second wait for the gateway port, and these gateway events:

```text
loading configuration…
starting HTTP server...
http server listening (0 plugins, 2.2s)
ready
```
