### PR TITLE
build: refresh pnpm and CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,16 @@ jobs:
         uses: cachix/install-nix-action@v31.11.1
 
       - name: Test JavaScript contracts
-        run: nix shell nixpkgs#nodejs_22 --command node --test maintainers/scripts/markdown-table.test.mjs
+        run: |
+          nix shell nixpkgs#nodejs_22 --command node --test \
+            scripts/select-openclaw-release.test.mjs \
+            maintainers/scripts/markdown-table.test.mjs \
+            nix/scripts/openclaw-runtime-plugin-version.test.mjs \
+            nix/scripts/patch-openclaw-npm-dist.test.mjs \
+            nix/scripts/normalize-pnpm-store-index.test.js
+
+      - name: Inspect flake outputs
+        run: nix flake show --accept-flake-config
 
       - name: Build Linux supported surface
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Verify flake.lock owners
         run: scripts/check-flake-lock-owners.sh
@@ -50,10 +50,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@v31.11.1
 
       - name: Test JavaScript contracts
         run: nix shell nixpkgs#nodejs_22 --command node --test maintainers/scripts/markdown-table.test.mjs
@@ -90,10 +90,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@v31.11.1
 
       - name: Build macOS supported surface
         timeout-minutes: 45
@@ -137,7 +137,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pin-stable-openclaw-version.yml
+++ b/.github/workflows/pin-stable-openclaw-version.yml
@@ -28,7 +28,7 @@ jobs:
       app_lag_releases: ${{ steps.select.outputs.app_lag_releases }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -72,10 +72,10 @@ jobs:
       validation_ok: ${{ steps.validation.outputs.validation_ok }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@v31.11.1
 
       - name: Materialize selected release
         id: materialize
@@ -164,10 +164,10 @@ jobs:
       validation_ok: ${{ steps.validation.outputs.validation_ok }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@v31.11.1
 
       - name: Materialize selected release
         id: materialize
@@ -303,12 +303,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@v31.11.1
 
       - name: Promote selected release
         env:

--- a/.github/workflows/publish-mirrored-release-tag.yml
+++ b/.github/workflows/publish-mirrored-release-tag.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout proven main commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Older repository history is available in git.
 ## Unreleased
 
 - Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
+- Update the private pnpm 12 runtime to 12.3.4 on Linux and macOS.
+- Refresh CI checkout to 7.0.1 and the Nix installer to 31.11.1, which fixes a Nix build crash.
 
 ## 2026-09-04
 

--- a/nix/packages/pnpm-12.nix
+++ b/nix/packages/pnpm-12.nix
@@ -12,11 +12,11 @@ let
     {
       aarch64-darwin = {
         package = "exe.darwin-arm64";
-        hash = "sha256-Y2JE8yGVuxL5svKHd7cZDvD7wJzs0ciUrylUw5GeZh4=";
+        hash = "sha256-9UrTZ9ikLa+dhIMOS9akXAlX4OMoekXaCMOguNBOx/c=";
       };
       x86_64-linux = {
         package = "exe.linux-x64";
-        hash = "sha256-ay8FtfwPEhyDBJlO5/tdKAH/7uNBDb2Zze2C8wbw2io=";
+        hash = "sha256-mxyV/EE2AMp1pR6+gzLXAZ3DVo/UGH9aXy30oVbvtlw=";
       };
     }
     .${stdenvNoCC.hostPlatform.system}
@@ -24,7 +24,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
-  version = "12.3.1";
+  version = "12.3.4";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/@pnpm/${platformSource.package}/-/${platformSource.package}-${finalAttrs.version}.tgz";


### PR DESCRIPTION
Update the private pnpm 12 runtime from 12.3.1 to 12.3.4, with independently downloaded hashes for the Linux and macOS executables. Keep pnpm 11.25.0 and the existing Node.js 22 runtime.

Refresh checkout to 7.0.1 and the Nix installer to 31.11.1 across CI and release workflows. The installer includes the Nix 2.35.2 build-crash fix. CI now runs all existing JavaScript contracts under Node.js 22 and inspects the flake outputs before building the supported surfaces.

PR #123 has landed. This PR is rebased onto main and contains only the dependency/CI update and its changelog entries.

Behavior proof for `babbcb84e0d51edc86dbf3341f4837aaddb681ee`:

- Downloaded the published pnpm 12.3.4 macOS executable and exercised it through the repository wrapper and runtime-check script. Offline local-tarball installation, package execution, unchanged lockfile verification, and rejection of an out-of-date frozen lockfile all passed; pnpm 11.25.0 passed the same checks.
- Exact-head Linux and macOS CI built both Nix pnpm packages and passed the same runtime contracts, plus the complete supported package/module/plugin/QMD groups and real systemd/launchd gateway activation.
- Both CI platforms exercised checkout 7.0.1 and Nix installer 31.11.1 successfully.

CI: https://github.com/openclaw/nix-openclaw/actions/runs/33987012739

All 9 JavaScript contracts also ran under Node.js 22 in CI, and nix flake show passed. Local JavaScript contracts: 9 passed. Flake provenance, shell syntax, and workflow YAML passed. Both local-candidate and committed-branch independent reviews completed with no actionable P0–P2 findings.

The separate upstream OpenClaw upgrade remains held: the published ACPX 2026.9.1 tarball has five runtime dependencies, no npm-shrinkwrap.json, and no bundled node_modules. The pinned wrapper's npm audit reports 11 advisories (7 high, 4 moderate); this maintenance PR does not claim to fix those upstream dependencies.




Observed local executable output:

```text
pnpm 11.25.0: offline install, execution, and frozen-lockfile rejection passed
pnpm 12.3.4: offline install, execution, and frozen-lockfile rejection passed
```
