### PR TITLE
docs: summarize unreleased packaging changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ Older repository history is available in git.
 
 ## Unreleased
 
+**Highlights:** More reliable Home Manager activation and isolated, updated package-manager tooling. Changes below cover the package state since `v2026.7.1`.
+
 - Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
-- Update the private pnpm 12 runtime to 12.3.4 on Linux and macOS.
+- Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
+- Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.25.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).
+- Restart the configured launchd labels and systemd user units with `openclaw-reload` instead of the old hardcoded labels.
+- Package upstream OpenClaw `2026.7.1-2`, retain runtime plugin version `2026.7.1` for correction releases, and repair the macOS `2026.7.1` app artifact hash; thanks @vincentkoc.
+- Preserve canonical scoped npm package encoding and fully escape generated CI table cells; thanks @vincentkoc (#114).
+- Document declarative Gmail hook session keys and their allowed prefix to prevent rejected callbacks (#113).
 - Refresh CI checkout to 7.0.1 and the Nix installer to 31.11.1, which fixes a Nix build crash.
 
 ## 2026-09-04


### PR DESCRIPTION
Rewrite Unreleased to summarize all user-visible packaging changes since the last published nix-openclaw tag, v2026.7.1. Lead with reliable Home Manager activation and private package-manager isolation, preserve contributor credit, and leave dated historical sections unchanged.

This PR targets main and contains rebased #124 at babbcb84e0d51edc86dbf3341f4837aaddb681ee followed by one changelog commit. Its file diff against #124 is changelog-only, and its complete file tree matches the previous candidate. A read-only post-squash merge preview reports a CHANGELOG.md conflict: after #124 is squash-merged, rebase the single changelog commit onto that actual merge commit before the final squash.

These changes are fixes and maintenance, but this repository mirrors upstream tags rather than allocating independent patch/minor versions. Release eligibility is currently false because gateway 2026.7.1-2 and app 2026.7.1 differ. Upstream 2026.9.1 promotion is separately blocked by the ACPX artifact dependency contract. No tag or release is proposed here.

Release-preparation proof for `3ef36b2cae992c73610b2ebdc7afdb5246ef7af6`:

Compared Unreleased with every commit after v2026.7.1 and retained all dated historical sections. The read-only release check reported:

```text
tag=v2026.7.1-2
source_version=2026.7.1-2
app_version=2026.7.1
eligible=false
skip_reason=source-app-version-mismatch
```

The complete stack passed Linux and macOS package/runtime/plugin/QMD checks and real systemd/launchd Home Manager activation at this exact head:
https://github.com/openclaw/nix-openclaw/actions/runs/33987681832

Both the documentation-only local review and the committed branch review completed with no actionable P0–P2 findings. No tag or release was created. After #124 is squash-merged, rebase the changelog commit onto its actual merge commit and reverify the new head.

