### PR TITLE
feat(runtime-plugins): consume npm package-lock release evidence for lockless plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
             scripts/select-openclaw-release.test.mjs \
             maintainers/scripts/markdown-table.test.mjs \
             nix/scripts/openclaw-runtime-plugin-version.test.mjs \
+            nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs \
+            nix/scripts/openclaw-runtime-plugin-prepare-npm.test.mjs \
+            nix/scripts/check-openclaw-runtime-plugin-locks.test.mjs \
             nix/scripts/patch-openclaw-npm-dist.test.mjs \
             nix/scripts/normalize-pnpm-store-index.test.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Older repository history is available in git.
 
 **Highlights:** More reliable Home Manager activation and isolated, updated package-manager tooling. Changes below cover the package state since `v2026.7.1`.
 
+- Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).
 - Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
 - Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
 - Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.25.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).

--- a/README.md
+++ b/README.md
@@ -136,16 +136,20 @@ Do not put bare package names or unprefixed `@scope/package` strings in
 
 ### Dependency Rule
 
-The rule is simple: if a plugin has runtime npm dependencies, it must publish
-either bundled `node_modules` or `npm-shrinkwrap.json`. No bundled deps and no
-shrinkwrap means no Nix package.
+If a plugin has runtime npm dependencies, it must publish bundled
+`node_modules`, `npm-shrinkwrap.json`, or, for supported OpenClaw catalog
+plugins, upstream npm `package-lock.json` release evidence bound to the pinned
+release SHA. Without one of these, there is no reproducible Nix package.
 
 Regular OpenClaw can solve npm dependencies during `openclaw plugins install`.
 nix-openclaw cannot do a mutable dependency solve during `home-manager switch`.
 If a package has `npm-shrinkwrap.json`, nix-openclaw can replay that dependency
-graph with `npmDepsHash`. If it bundles `node_modules`, nix-openclaw validates
-and copies the bundled deps. If it has neither, ask the plugin author to publish
-shrinkwrap or bundled runtime deps.
+graph with `npmDepsHash`. For lockless OpenClaw catalog plugins, the pin updater
+can instead select the exact package name and version from the upstream
+`openclaw-<version>-dependency-evidence.zip` asset, record its lock and hashes,
+and replay it during the Nix build. If a plugin bundles `node_modules`,
+nix-openclaw validates and copies the bundled deps. Other plugin authors must
+publish shrinkwrap or bundled runtime deps.
 
 ### npm and ClawHub Sources
 

--- a/docs/plugins-maintainers.md
+++ b/docs/plugins-maintainers.md
@@ -54,6 +54,7 @@ and source SHA, and writes `<attrName>.package-lock.json` next to its `.nix`
 lock. The generated record includes `npmDepsHash`, `npmPackageLockFile`,
 `npmPackageLockSha256`, and `npmPackageLockEvidence` (asset identity, Nix hash,
 source, source SHA, generation time). Only build copies are normalized.
+Entries must declare an empty `omittedWorkspaceDependencies` array; partial locks are skipped as `package-lock-evidence-incomplete`, with the omitted dependency names in `report.json`.
 
 Verification has two tiers. Pin-time validation in `scripts/update-pins.sh`
 sets `OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET=1`: for every package-lock

--- a/docs/plugins-maintainers.md
+++ b/docs/plugins-maintainers.md
@@ -55,6 +55,16 @@ lock. The generated record includes `npmDepsHash`, `npmPackageLockFile`,
 `npmPackageLockSha256`, and `npmPackageLockEvidence` (asset identity, Nix hash,
 source, source SHA, generation time). Only build copies are normalized.
 
+Verification has two tiers. Pin-time validation in `scripts/update-pins.sh`
+sets `OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET=1`: for every package-lock
+record labeled `release`, the checker prefetches the pinned release evidence
+asset, checks its Nix hash, and compares the exact selected lock bytes and
+SHA-256 with the committed sidecar. Missing assets, missing entries, and
+mismatches fail validation. This verification ignores the local ZIP override
+for release records. Pure Nix CI keeps the existing structural and hash checks
+without network access; it does not enable asset verification. Explicitly
+allowed `override` records remain local validation inputs, not release proof.
+
 Rows lacking all three dependency shapes remain skipped as
 `runtime-dependencies-without-shrinkwrap`; see `report.json` for the current
 supported ids and diagnostics. Regenerate after upstream supplies a supported

--- a/docs/plugins-maintainers.md
+++ b/docs/plugins-maintainers.md
@@ -21,7 +21,7 @@ Current nix-openclaw `customPlugins` supports nix-openclaw plugins: package bina
 
 PR #81 (`fix: copy plugin manifests into dist/extensions`) was related but not the missing external-plugin feature. It fixed bundled upstream plugin manifests missing from the packaged gateway `dist/extensions/*/openclaw.plugin.json` tree. Current packaging already copies those manifests and checks them in `openclaw-package-contents`.
 
-Supported OpenClaw runtime plugins are fetched as pinned Nix artifacts, validated as OpenClaw runtime plugin roots, and wired through OpenClaw's own `plugins.load.paths` and `plugins.entries` config. Runtime dependencies must be absent, bundled, or materialized from `npmDepsHash` and package-local shrinkwrap during the Nix build. Do not route npm runtime plugins through `customPlugins`; that surface is for nix-openclaw plugin flakes.
+Supported OpenClaw runtime plugins are fetched as pinned Nix artifacts, validated as OpenClaw runtime plugin roots, and wired through OpenClaw's own `plugins.load.paths` and `plugins.entries` config. Runtime dependencies must be absent, bundled, or materialized from `npmDepsHash` and either package-local shrinkwrap or upstream npm package-lock release evidence during the Nix build. Do not route npm runtime plugins through `customPlugins`; that surface is for nix-openclaw plugin flakes.
 
 ## OpenClaw Runtime Install Surfaces
 
@@ -32,9 +32,9 @@ Regular OpenClaw has one mutable lifecycle command, `openclaw plugins install`, 
 | `openclaw plugins enable workboard` | Enables a plugin that already ships inside the OpenClaw package. | Set the upstream config entry directly, for example `programs.openclaw.config.plugins.entries.workboard.enabled = true;`. |
 | `openclaw plugins install @openclaw/brave-plugin` | Installs an official inventory plugin with no runtime npm dependencies. | If the generated lock contains `brave`, users write `programs.openclaw.runtimePlugins = [ "brave" ];`. |
 | `openclaw plugins install @openclaw/slack` | Installs an official inventory plugin. Upstream may use a bundled source, npm, or official inventory metadata. | If generated support exists, users write `programs.openclaw.runtimePlugins = [ "slack" ];`. |
-| `openclaw plugins install npm:@openclaw/memory-lancedb` | Installs an npm package and resolves dependencies during install. | The generator writes `dependencyMode = "shrinkwrap"` and `npmDepsHash`; users still write only `runtimePlugins = [ "memory-lancedb" ];`. |
+| `openclaw plugins install npm:@openclaw/memory-lancedb` | Installs an npm package and resolves dependencies during install. | The generator writes `dependencyMode = "shrinkwrap"` or `"package-lock"` with `npmDepsHash`; users still write only `runtimePlugins = [ "memory-lancedb" ];`. |
 | `openclaw plugins install clawhub:@openclaw/whatsapp` | Resolves ClawHub metadata, verifies the artifact, then installs the package root. | The generator resolves ClawHub at update time and feeds the fixed artifact through the same packageability rule. The current OpenClaw 2026.6.1 lock supports WhatsApp and Matrix this way. |
-| `openclaw plugins install @tencent-weixin/openclaw-weixin` | Installs a package whose current artifact lets npm solve dependencies at install time. | No `runtimePlugins` id until upstream publishes `npm-shrinkwrap.json` or bundled `node_modules`, then maintainers regenerate the lock. |
+| `openclaw plugins install @tencent-weixin/openclaw-weixin` | Installs a package whose current artifact lets npm solve dependencies at install time. | No `runtimePlugins` id until upstream publishes `npm-shrinkwrap.json`, bundled `node_modules`, or matching npm package-lock release evidence, then maintainers regenerate the lock. |
 | `openclaw plugins install npm:@scope/plugin@1.2.3` | Installs an arbitrary npm package into a mutable per-plugin npm project. | Use `programs.openclaw.runtimePluginSources = [{ id = "..."; spec = "npm:@scope/plugin@1.2.3"; hash = lib.fakeHash; }];`. If the build reports shrinkwrap materialization, add `npmDepsHash = lib.fakeHash;`, rebuild, then replace both hashes. |
 | `openclaw plugins install clawhub:@scope/plugin@1.2.3` | Resolves an arbitrary ClawHub package to a plugin artifact. | Use `programs.openclaw.runtimePluginSources = [{ id = "..."; spec = "clawhub:@scope/plugin@1.2.3"; hash = lib.fakeHash; }];`. If the build reports shrinkwrap materialization, add `npmDepsHash = lib.fakeHash;`, rebuild, then replace both hashes. |
 | `openclaw plugins install npm-pack:./plugin.tgz` | Installs a local npm-pack tarball through npm install semantics. | `runtimePluginSources.url` accepts a fixed HTTPS tarball URL with a Nix hash. Local dev tarballs remain outside the declarative runtime plugin API. |
@@ -44,18 +44,33 @@ Regular OpenClaw has one mutable lifecycle command, `openclaw plugins install`, 
 
 The maintainer rule is: first resolve upstream source details into a package root with fixed identity, then decide whether that root is Nix-packageable. For OpenClaw official inventory rows, expose the generated plugin id. For arbitrary npm or ClawHub packages, require a locked `runtimePluginSources` record. If an official row is not packageable, leave it out of the generated lock and keep the diagnostic in `nix/generated/openclaw-runtime-plugins/report.json`. Do not turn report skip reasons into user-facing product categories.
 
-For OpenClaw 2026.6.1 the generated lock supports 34 official inventory rows:
-dependency-free roots, bundled `node_modules` roots, and seven shrinkwrapped
-roots (`acpx`, `codex`, `copilot`, `matrix`, `memory-lancedb`, `tlon`,
-`whatsapp`). No current shrinkwrapped official inventory artifact is left out of the lock.
+Generated locks support dependency-free roots, bundled `node_modules`,
+package-local shrinkwrap, and `dependencyMode = "package-lock"` for lockless
+catalog packages with matching upstream release evidence. OpenClaw 2026.8.1+
+plugins that opt out of bundling can use this last mode once upstream ships
+`dependency-evidence/npm-package-locks.json` in its dependency evidence ZIP.
+The updater selects the exact package name/version, verifies the release tag
+and source SHA, and writes `<attrName>.package-lock.json` next to its `.nix`
+lock. The generated record includes `npmDepsHash`, `npmPackageLockFile`,
+`npmPackageLockSha256`, and `npmPackageLockEvidence` (asset identity, Nix hash,
+source, source SHA, generation time). Only build copies are normalized.
 
-The remaining real skipped rows are Weixin, Yuanbao, and WeCom. Their current
-published artifacts declare runtime dependencies but contain neither
-`npm-shrinkwrap.json` nor bundled `node_modules`. The user-facing consequence is
-simple: those ids are not available through `runtimePlugins` in this generated
-lock. The fix is upstream publishing shrinkwrap or bundled runtime dependencies,
-then regenerating nix-openclaw's lock. PixVerse is only a duplicate inventory row
-after the first row is already emitted.
+Rows lacking all three dependency shapes remain skipped as
+`runtime-dependencies-without-shrinkwrap`; see `report.json` for the current
+supported ids and diagnostics. Regenerate after upstream supplies a supported
+shape. No registry range resolution happens during activation or builds.
+
+For maintainer validation before the release asset exists, set
+`OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_EVIDENCE_ZIP=/absolute/path/evidence.zip`
+when running `scripts/update-pins.sh apply` or the runtime lock updater directly.
+The ZIP must still match `openclaw-source.nix`'s `releaseTag` and `rev`; its asset
+name uses `releaseVersion`, while package selection uses the artifact version
+(which may be `runtimePluginVersion` on correction releases). Override records
+require `OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE=1` for the lock checker.
+Pass that environment variable with `nix build --impure` for local Nix checks;
+pure CI rejects override records. Regenerate from the published release asset
+before landing generated locks. The updater's `--check` compares sidecar bytes
+and detects missing or stale sidecars without modifying generated files.
 
 ## Interface Contract
 Every nix-openclaw plugin exposes the same fields through the `openclawPlugin` flake output:

--- a/maintainers/packaging.md
+++ b/maintainers/packaging.md
@@ -37,6 +37,7 @@ This repo ships a working Nix package for OpenClaw users, not just a pin mirror.
 - QMD is the Nix-supported local memory backend. Keep `qmd` internal to the OpenClaw runtime PATH, and pull it into the closure only when users opt in with upstream config.
 - ACPX compatibility files are staged at build time from locked package inputs,
   not installed or repaired by npm at runtime.
+- Lockless upstream runtime plugins are materialized from upstream npm package-lock evidence bound to the pinned release SHA and exact package name/version. Preserve the evidence lock bytes and hashes; normalize only build copies. Nothing resolves dependencies from live registry ranges. Local evidence overrides require explicit maintainer validation and cannot pass pure CI.
 - Keep files under 400 lines unless a maintainer explicitly accepts the larger file.
 
 ## Investigations

--- a/nix/checks/openclaw-runtime-plugin-locks.nix
+++ b/nix/checks/openclaw-runtime-plugin-locks.nix
@@ -23,11 +23,17 @@ stdenvNoCC.mkDerivation {
     OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR = "${../generated/openclaw-runtime-plugins}";
     OPENCLAW_RUNTIME_PLUGIN_LOCKS_JSON = "${generatedLocksJson}";
     OPENCLAW_SOURCE_INFO_PATH = "${../sources/openclaw-source.nix}";
+    # Pure CI evaluation cannot opt into local release-evidence overrides.
+    OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE =
+      builtins.getEnv "OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE";
   };
 
   doCheck = true;
   checkPhase = ''
     ${nodejs_22}/bin/node --test ${scriptsDir}/openclaw-runtime-plugin-version.test.mjs
+    ${nodejs_22}/bin/node --test ${scriptsDir}/openclaw-runtime-plugin-package-locks.test.mjs \
+      ${scriptsDir}/openclaw-runtime-plugin-prepare-npm.test.mjs \
+      ${scriptsDir}/check-openclaw-runtime-plugin-locks.test.mjs
     ${nodejs_22}/bin/node ${scriptsDir}/check-openclaw-runtime-plugin-locks.mjs
   '';
   installPhase = "${../scripts/empty-install.sh}";

--- a/nix/lib/openclaw-runtime-plugin.nix
+++ b/nix/lib/openclaw-runtime-plugin.nix
@@ -63,7 +63,11 @@ let
       throw "runtime plugin ${lock.id} must define tarballUrl, sourceUrl, or sourceSpec";
   dependencyMode =
     lock.dependencyMode or (if (lock.npmDepsHash or null) != null then "shrinkwrap" else "auto");
-  isShrinkwrap = dependencyMode == "shrinkwrap";
+  isLocked = builtins.elem dependencyMode [ "shrinkwrap" "package-lock" ];
+  packageLockEnv = lib.optionalAttrs (dependencyMode == "package-lock") {
+    OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE =
+      "${../generated/openclaw-runtime-plugins}/${lock.npmPackageLockFile}";
+  };
   hasRuntimeDependencies =
     (lock.dependencies or { }) != { } || (lock.optionalDependencies or { }) != { };
   safeName = lib.replaceStrings [ "@" "/" ":" ] [ "" "-" "-" ] lock.id;
@@ -82,24 +86,24 @@ let
       nativeBuildInputs = [
         nodejs_22
       ]
-      ++ lib.optionals isShrinkwrap [
+      ++ lib.optionals isLocked [
         nodejs_22.python
         npmHooksForNode.npmConfigHook
       ]
-      ++ lib.optionals (isShrinkwrap && stdenvNoCC.hostPlatform.isDarwin) [ cctools ];
+      ++ lib.optionals (isLocked && stdenvNoCC.hostPlatform.isDarwin) [ cctools ];
 
-      npmInstallFlags = lib.optionals isShrinkwrap [
+      npmInstallFlags = lib.optionals isLocked [
         "--omit=dev"
         "--omit=peer"
         "--legacy-peer-deps"
       ];
 
-      npmRebuildFlags = lib.optionals isShrinkwrap [ "--ignore-scripts" ];
+      npmRebuildFlags = lib.optionals isLocked [ "--ignore-scripts" ];
 
       dontConfigure = true;
       dontBuild = true;
 
-      postPatch = lib.optionalString isShrinkwrap ''
+      postPatch = lib.optionalString isLocked ''
         ${nodejs_22}/bin/node ${../scripts/openclaw-runtime-plugin-prepare-npm.mjs}
       '';
 
@@ -117,6 +121,7 @@ let
         OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = dependencyMode;
         OPENCLAW_RUNTIME_PLUGIN_LINK_PEER_OPENCLAW = if linkOpenClawPeer then "1" else "0";
       }
+      // packageLockEnv
       // lib.optionalAttrs linkOpenClawPeer {
         OPENCLAW_GATEWAY_PACKAGE = "${openclawPackage}";
       }
@@ -151,20 +156,20 @@ let
         platforms = platforms.darwin ++ platforms.linux;
       };
     }
-    // lib.optionalAttrs isShrinkwrap {
-      npmDeps = fetchNpmDeps {
+    // lib.optionalAttrs isLocked {
+      npmDeps = fetchNpmDeps ({
         name = "${packageName}-npm-deps";
         src = pluginSrc;
         sourceRoot = "package";
         hash = lock.npmDepsHash;
         nativeBuildInputs = [ nodejs_22 ];
-        OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = "shrinkwrap";
+        OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = dependencyMode;
         OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME = lock.packageName or "";
         OPENCLAW_RUNTIME_PLUGIN_VERSION = lock.version or "";
         postPatch = ''
           ${nodejs_22}/bin/node ${../scripts/openclaw-runtime-plugin-prepare-npm.mjs}
         '';
-      };
+      } // packageLockEnv);
     }
   );
 in

--- a/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 
 const generatedDir = process.env.OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR;
 if (!generatedDir) {
@@ -161,7 +162,7 @@ for (const row of supported) {
   assert(row.selectedSource === "npm" || row.selectedSource === "clawhub", `supported row ${row.id} has invalid source`);
   assert(row.packageName, `supported row ${row.id} has no packageName`);
   assert(
-    row.dependencyMode === "none" || row.dependencyMode === "bundled" || row.dependencyMode === "shrinkwrap",
+    ["none", "bundled", "shrinkwrap", "package-lock"].includes(row.dependencyMode),
     `supported row ${row.id} has invalid dependencyMode`,
   );
   assert(!/[~^*]|latest/.test(row.version), `supported row ${row.id} has a floating version`);
@@ -189,11 +190,29 @@ for (const row of supported) {
   assert(lockSourceIsValid(lock), `lock ${row.id} has invalid source metadata`);
   assert(!lock.npmIntegrity || /^(sha512|sha384|sha256)-/.test(lock.npmIntegrity), `lock ${row.id} has invalid npm SRI integrity`);
   assert(/^sha256-/.test(lock.nixHash), `lock ${row.id} has missing Nix hash`);
-  if (lock.dependencyMode === "shrinkwrap") {
+  if (["shrinkwrap", "package-lock"].includes(lock.dependencyMode)) {
     assert(/^sha256-/.test(lock.npmDepsHash), `lock ${row.id} has missing npmDepsHash`);
-    assert((lock.bundledPackageRoots ?? []).length === 0, `lock ${row.id} shrinkwrap mode should not list bundled roots`);
+    assert((lock.bundledPackageRoots ?? []).length === 0, `lock ${row.id} ${lock.dependencyMode} mode should not list bundled roots`);
   } else {
     assert(!lock.npmDepsHash, `lock ${row.id} has unexpected npmDepsHash`);
+  }
+  if (lock.dependencyMode === "package-lock") {
+    assert(/^sha256-[A-Za-z0-9+/]{43}=$/.test(lock.npmDepsHash), `lock ${row.id} has invalid npmDepsHash SRI`);
+    assert(typeof lock.npmPackageLockFile === "string"
+      && /^[A-Za-z0-9_-]+\.package-lock\.json$/.test(lock.npmPackageLockFile),
+    `lock ${row.id} has invalid npmPackageLockFile`);
+    const lockPath = path.join(generatedDir, lock.npmPackageLockFile);
+    assert(fs.existsSync(lockPath) && fs.lstatSync(lockPath).isFile(), `lock ${row.id} package-lock file is missing`);
+    const digest = crypto.createHash("sha256").update(fs.readFileSync(lockPath)).digest("hex");
+    assert(digest === lock.npmPackageLockSha256, `lock ${row.id} npmPackageLockSha256 mismatch`);
+    const evidence = lock.npmPackageLockEvidence;
+    assert(typeof evidence?.assetUrl === "string" && evidence.assetUrl.startsWith(
+      `https://github.com/openclaw/openclaw/releases/download/${sourceInfo.releaseTag}/`,
+    ), `lock ${row.id} has invalid package-lock evidence assetUrl`);
+    assert(evidence?.sourceSha === sourceInfo.rev, `lock ${row.id} package-lock evidence sourceSha mismatch`);
+    assert(evidence?.source === "release" || (evidence?.source === "override"
+      && process.env.OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE === "1"),
+    `lock ${row.id} package-lock evidence source must be release (maintainer override requires OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE=1)`);
   }
   assert(!lock.minHostVersion || satisfiesVersionRange(report.openclawVersion, lock.minHostVersion), `lock ${row.id} minHostVersion excludes OpenClaw ${report.openclawVersion}`);
   assert(!lock.openclawCompat || satisfiesVersionRange(report.openclawVersion, lock.openclawCompat), `lock ${row.id} openclawCompat excludes OpenClaw ${report.openclawVersion}`);

--- a/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/check-openclaw-runtime-plugin-locks.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
+import { verifyNpmPackageLockEvidenceAssets } from "./openclaw-runtime-plugin-package-locks.mjs";
 
 const generatedDir = process.env.OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR;
 if (!generatedDir) {
@@ -235,3 +236,5 @@ assert(
   acpx.version === report.runtimePluginVersion,
   `ACPX version ${acpx.version} does not match runtime plugin version ${report.runtimePluginVersion}`,
 );
+
+verifyNpmPackageLockEvidenceAssets({ locks, generatedDir, sourceInfo });

--- a/nix/scripts/check-openclaw-runtime-plugin-locks.test.mjs
+++ b/nix/scripts/check-openclaw-runtime-plugin-locks.test.mjs
@@ -6,9 +6,11 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   releaseTag, releaseVersion, releaseRev, version, sri,
-  jsonText, sha256, packageLock, tempDir, writeJson,
+  jsonText, sha256, packageLock, tempDir, writeJson, evidenceReport,
 } from "./openclaw-runtime-plugin-package-locks.fixtures.mjs";
-import { dependencyEvidenceAssetName, dependencyEvidenceAssetUrl } from "./openclaw-runtime-plugin-package-locks.mjs";
+import {
+  dependencyEvidenceAssetName, dependencyEvidenceAssetUrl, verifyNpmPackageLockEvidenceAssets,
+} from "./openclaw-runtime-plugin-package-locks.mjs";
 
 const script = fileURLToPath(new URL("./check-openclaw-runtime-plugin-locks.mjs", import.meta.url));
 
@@ -53,10 +55,103 @@ function fixture(t) {
         ...process.env, OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR: directory,
         OPENCLAW_RUNTIME_PLUGIN_LOCKS_JSON: locksPath, OPENCLAW_SOURCE_INFO_PATH: sourceInfoPath,
         OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE: allow,
+        OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET: "",
       } });
     },
   };
 }
+
+function verificationFixture(t) {
+  const data = fixture(t);
+  const published = { ...evidenceReport(), ...data.locks.acpx.npmPackageLockEvidence };
+  const options = {
+    locks: data.locks, generatedDir: data.directory, verifyAssets: true,
+    sourceInfo: { releaseTag, releaseVersion, rev: releaseRev },
+  };
+  return { ...data, published, options };
+}
+
+test("release verification loads the pinned asset once and explicitly disables ZIP overrides", (t) => {
+  const { locks, published, options } = verificationFixture(t);
+  locks.second = { ...locks.acpx, id: "second" };
+  let loads = 0;
+  verifyNpmPackageLockEvidenceAssets(options, { loadEvidence: (input) => {
+    assert.deepEqual(input, { releaseTag, releaseVersion, releaseRev, overrideZipPath: "" });
+    loads += 1;
+    return published;
+  } });
+  assert.equal(loads, 1);
+});
+
+test("release verification is enabled only by the exact env value 1", (t) => {
+  const { published, options } = verificationFixture(t);
+  delete options.verifyAssets;
+  const oldValue = process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET;
+  t.after(() => {
+    if (oldValue === undefined) delete process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET;
+    else process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET = oldValue;
+  });
+  let loads = 0;
+  const loader = { loadEvidence: () => { loads += 1; return published; } };
+  for (const value of ["", "0", "true"]) {
+    process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET = value;
+    verifyNpmPackageLockEvidenceAssets(options, loader);
+  }
+  assert.equal(loads, 0);
+  process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET = "1";
+  verifyNpmPackageLockEvidenceAssets(options, loader);
+  assert.equal(loads, 1);
+});
+
+test("asset verification leaves override records to the existing structural gate", (t) => {
+  const { locks, options } = verificationFixture(t);
+  locks.acpx.npmPackageLockEvidence.source = "override";
+  verifyNpmPackageLockEvidenceAssets(options, { loadEvidence: () => assert.fail("must not fetch override evidence") });
+});
+
+test("a relabeled override passes pure checks but fails published lock verification", (t) => {
+  const { directory, locks, run, published, options } = verificationFixture(t);
+  const altered = packageLock();
+  altered.packages["node_modules/acpx"].version = "1.0.2";
+  const text = jsonText(altered);
+  fs.writeFileSync(path.join(directory, "acpx.package-lock.json"), text);
+  locks.acpx.npmPackageLockSha256 = sha256(text);
+  const pure = run();
+  assert.equal(pure.status, 0, pure.stderr);
+  assert.throws(() => verifyNpmPackageLockEvidenceAssets(options, { loadEvidence: () => published }),
+    /published evidence lockSha256 mismatch/);
+});
+
+for (const [label, mutate, pattern] of [
+  ["asset hash", ({ published }) => { published.assetNixHash = "different"; }, /assetNixHash mismatch/],
+  ["asset URL", ({ published }) => { published.assetUrl = "different"; }, /assetUrl mismatch/],
+  ["package version", ({ published }) => { published.packages[0].version = "different"; }, /is missing @openclaw\/acpx/],
+  ["sidecar bytes", ({ directory }) => {
+    fs.appendFileSync(path.join(directory, "acpx.package-lock.json"), "\n");
+  }, /sidecar bytes differ/],
+  ["second lock digest", ({ locks }) => {
+    locks.second = { ...locks.acpx, id: "second", npmPackageLockSha256: "different" };
+  }, /lock second published evidence lockSha256 mismatch/],
+]) {
+  test(`release verification rejects mismatched ${label}`, (t) => {
+    const data = verificationFixture(t);
+    mutate(data);
+    assert.throws(() => verifyNpmPackageLockEvidenceAssets(data.options, { loadEvidence: () => data.published }), pattern);
+  });
+}
+
+test("release verification fails loudly when the asset or npm report is missing", (t) => {
+  const { options } = verificationFixture(t);
+  assert.throws(() => verifyNpmPackageLockEvidenceAssets(options, { loadEvidence: () => null }),
+    /published npm package-lock evidence asset or report is missing/);
+});
+
+test("release verification propagates download failures", (t) => {
+  const { options } = verificationFixture(t);
+  assert.throws(() => verifyNpmPackageLockEvidenceAssets(options, {
+    loadEvidence: () => { throw new Error("HTTP error 503"); },
+  }), /HTTP error 503/);
+});
 
 test("checker accepts release evidence and gates override evidence explicitly", (t) => {
   const { locks, run } = fixture(t);

--- a/nix/scripts/check-openclaw-runtime-plugin-locks.test.mjs
+++ b/nix/scripts/check-openclaw-runtime-plugin-locks.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  releaseTag, releaseVersion, releaseRev, version, sri,
+  jsonText, sha256, packageLock, tempDir, writeJson,
+} from "./openclaw-runtime-plugin-package-locks.fixtures.mjs";
+import { dependencyEvidenceAssetName, dependencyEvidenceAssetUrl } from "./openclaw-runtime-plugin-package-locks.mjs";
+
+const script = fileURLToPath(new URL("./check-openclaw-runtime-plugin-locks.mjs", import.meta.url));
+
+function fixture(t) {
+  const directory = tempDir(t);
+  const sourceInfoPath = path.join(tempDir(t), "source.nix");
+  fs.writeFileSync(sourceInfoPath, [
+    ["releaseVersion", releaseVersion], ["releaseTag", releaseTag], ["rev", releaseRev],
+    ["runtimePluginVersion", version], ["hash", sri],
+  ].map(([key, value]) => `  ${key} = "${value}";`).join("\n"));
+  const supported = ["acpx", "brave", "slack", "discord", "diagnostics-prometheus"].map((id) => ({
+    id, status: "supported", selectedSource: "npm", packageName: `@openclaw/${id}`, version,
+    dependencyMode: id === "acpx" ? "package-lock" : "none",
+  }));
+  const locks = Object.fromEntries(supported.map(({ status, ...row }) => [row.id, {
+    ...row, label: null, kind: null, catalogSource: null, catalogFile: null,
+    catalogEntryName: null, catalogDefaultChoice: null, openclawCompat: null, peerOpenClaw: null,
+    manifestId: row.id, tarballUrl: "https://registry.npmjs.org/test.tgz", nixHash: sri,
+  }]));
+  const lockText = jsonText(packageLock());
+  Object.assign(locks.acpx, {
+    npmDepsHash: sri, npmPackageLockFile: "acpx.package-lock.json", npmPackageLockSha256: sha256(lockText),
+    bundledPackageRoots: [], npmPackageLockEvidence: {
+      source: "release", sourceSha: releaseRev, generatedAt: "2026-09-06T12:00:00.000Z",
+      assetName: dependencyEvidenceAssetName(releaseVersion), assetNixHash: sri,
+      assetUrl: dependencyEvidenceAssetUrl({ releaseTag, releaseVersion }),
+    },
+  });
+  fs.writeFileSync(path.join(directory, "acpx.package-lock.json"), lockText);
+  fs.writeFileSync(path.join(directory, "default.nix"), supported.map(({ id }) => `${id} = import ./${id}.nix;`).join("\n"));
+  for (const { id } of supported) fs.writeFileSync(path.join(directory, `${id}.nix`), "{}\n");
+  writeJson(path.join(directory, "report.json"), {
+    openclawVersion: releaseVersion, runtimePluginVersion: version, openclawReleaseTag: releaseTag,
+    openclawRev: releaseRev, openclawHash: sri, supported, skipped: [],
+  });
+  return {
+    directory, locks,
+    run: (allow = "") => {
+      const locksPath = path.join(directory, "locks.json");
+      writeJson(locksPath, locks);
+      return spawnSync(process.execPath, [script], { encoding: "utf8", env: {
+        ...process.env, OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR: directory,
+        OPENCLAW_RUNTIME_PLUGIN_LOCKS_JSON: locksPath, OPENCLAW_SOURCE_INFO_PATH: sourceInfoPath,
+        OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE: allow,
+      } });
+    },
+  };
+}
+
+test("checker accepts release evidence and gates override evidence explicitly", (t) => {
+  const { locks, run } = fixture(t);
+  let result = run();
+  assert.equal(result.status, 0, result.stderr);
+  locks.acpx.npmPackageLockEvidence.source = "override";
+  result = run();
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /source must be release/);
+  assert.notEqual(run("true").status, 0);
+  result = run("1");
+  assert.equal(result.status, 0, result.stderr);
+  locks.acpx.npmPackageLockEvidence.source = "unknown";
+  assert.notEqual(run("1").status, 0);
+});
+
+for (const [label, mutate, pattern] of [
+  ["digest", (lock) => { lock.npmPackageLockSha256 = "wrong"; }, /npmPackageLockSha256 mismatch/],
+  ["missing lock", (lock) => { lock.npmPackageLockFile = "missing.package-lock.json"; }, /file is missing/],
+  ["escaping lock", (lock) => { lock.npmPackageLockFile = "../acpx.package-lock.json"; }, /invalid npmPackageLockFile/],
+  ["npm hash", (lock) => { lock.npmDepsHash = "sha256-invalid"; }, /invalid npmDepsHash SRI/],
+  ["bundled roots", (lock) => { lock.bundledPackageRoots = ["node_modules/acpx"]; }, /should not list bundled roots/],
+  ["release URL", (lock) => { lock.npmPackageLockEvidence.assetUrl = "https://example.com/evidence.zip"; }, /assetUrl/],
+  ["release tag", (lock) => { lock.npmPackageLockEvidence.assetUrl = dependencyEvidenceAssetUrl({ releaseTag: "wrong", releaseVersion }); }, /assetUrl/],
+  ["source SHA", (lock) => { lock.npmPackageLockEvidence.sourceSha = "wrong"; }, /sourceSha mismatch/],
+]) {
+  test(`checker rejects bad ${label} even with override enabled`, (t) => {
+    const { locks, run } = fixture(t);
+    locks.acpx.npmPackageLockEvidence.source = "override";
+    mutate(locks.acpx);
+    const result = run("1");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, pattern);
+  });
+}

--- a/nix/scripts/openclaw-runtime-plugin-install.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-install.mjs
@@ -199,7 +199,7 @@ function reachablePackageRoots(pluginRoot, rootPackageJson) {
   return reachable;
 }
 
-function pruneExtraneousShrinkwrapPackages(pluginRoot, rootPackageJson) {
+function pruneExtraneousLockedPackages(pluginRoot, rootPackageJson) {
   const nodeModulesDir = path.join(pluginRoot, "node_modules");
   if (!fs.existsSync(nodeModulesDir)) {
     return;
@@ -283,8 +283,8 @@ const hasRuntimeDependencies =
     ? expectedHasRuntimeDependencies === "1"
     : Object.keys(dependencies).length > 0 || Object.keys(optionalDependencies).length > 0;
 
-if (dependencyMode === "shrinkwrap") {
-  pruneExtraneousShrinkwrapPackages(out, packageJson);
+if (["shrinkwrap", "package-lock"].includes(dependencyMode)) {
+  pruneExtraneousLockedPackages(out, packageJson);
   removeNodeModulesBinDirs(path.join(out, "node_modules"));
 }
 
@@ -361,7 +361,7 @@ if (hasRuntimeDependencies) {
       );
     } else {
       fail(
-        `runtime plugin ${expectedId} has runtime dependencies but does not bundle node_modules; publish npm-shrinkwrap.json and set npmDepsHash = lib.fakeHash`,
+        `runtime plugin ${expectedId} has runtime dependencies but no bundled node_modules, npm-shrinkwrap.json, or upstream npm package-lock evidence; publish shrinkwrap and set npmDepsHash = lib.fakeHash, or regenerate the catalog locks once upstream ships evidence`,
       );
     }
   }
@@ -379,9 +379,10 @@ if (hasRuntimeDependencies) {
         }
       }
     }
-  } else if (dependencyMode === "shrinkwrap") {
-    if (!fs.existsSync(path.join(out, "npm-shrinkwrap.json"))) {
-      fail(`runtime plugin ${expectedId} has runtime dependencies but no npm-shrinkwrap.json`);
+  } else if (["shrinkwrap", "package-lock"].includes(dependencyMode)) {
+    const lockName = dependencyMode === "package-lock" ? "package-lock.json" : "npm-shrinkwrap.json";
+    if (!fs.existsSync(path.join(out, lockName))) {
+      fail(`runtime plugin ${expectedId} has runtime dependencies but no ${lockName}`);
     }
     for (const dependencyName of Object.keys(packageJson.dependencies ?? {}).sort()) {
       const dependencyRoot = packageRootForName(dependencyName);
@@ -390,7 +391,7 @@ if (hasRuntimeDependencies) {
       }
     }
     // Optional dependencies may be omitted by npm for the current platform.
-    // The generator still requires shrinkwrap whenever optional deps exist.
+    // The generator still requires a lock whenever optional deps exist.
   } else {
     fail(`runtime plugin ${expectedId} has invalid dependency mode ${dependencyMode}`);
   }

--- a/nix/scripts/openclaw-runtime-plugin-install.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-install.mjs
@@ -361,7 +361,7 @@ if (hasRuntimeDependencies) {
       );
     } else {
       fail(
-        `runtime plugin ${expectedId} has runtime dependencies but no bundled node_modules, npm-shrinkwrap.json, or upstream npm package-lock evidence; publish shrinkwrap and set npmDepsHash = lib.fakeHash, or regenerate the catalog locks once upstream ships evidence`,
+        `runtime plugin ${expectedId} has runtime dependencies but no bundled node_modules, npm-shrinkwrap.json, or upstream npm package-lock evidence; publish npm-shrinkwrap.json and set npmDepsHash = lib.fakeHash, or regenerate the catalog locks once upstream ships evidence`,
       );
     }
   }

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.fixtures.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.fixtures.mjs
@@ -36,6 +36,7 @@ export function packageEntry(lock = packageLock()) {
   return {
     packageDir: "extensions/acpx", name: packageName, version,
     bundleRuntimeDependencies: false, dependencyCount: 1, optionalDependencyCount: 0,
+    omittedWorkspaceDependencies: [],
     lockSha256: sha256(jsonText(lock)), lock,
   };
 }
@@ -44,6 +45,7 @@ export function evidenceReport(entry = packageEntry()) {
   return {
     schemaVersion: 1, generatedAt: "2026-09-06T12:00:00.000Z",
     sourceSha: releaseRev, lockfileVersion: 3, packages: [entry],
+    packagesWithOmittedWorkspaceDependencies: entry.omittedWorkspaceDependencies?.length > 0 ? 1 : 0,
   };
 }
 

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.fixtures.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.fixtures.mjs
@@ -1,0 +1,58 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const releaseTag = "v2026.9.1-2";
+export const releaseVersion = "2026.9.1-2";
+export const releaseRev = "a".repeat(40);
+export const packageName = "@openclaw/acpx";
+export const version = "2026.9.1";
+export const sri = `sha256-${Buffer.alloc(32).toString("base64")}`;
+export const jsonText = (value) => `${JSON.stringify(value, null, 2)}\n`;
+export const sha256 = (text) => crypto.createHash("sha256").update(text).digest("hex");
+export const writeJson = (file, value) => fs.writeFileSync(file, jsonText(value));
+
+export function tempDir(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lock-test-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+export function packageLock() {
+  return {
+    name: packageName, version, lockfileVersion: 3, requires: true,
+    packages: {
+      "": { name: packageName, version, dependencies: { acpx: "^1.0.0" } },
+      "node_modules/acpx": {
+        version: "1.0.1", resolved: "https://registry.npmjs.org/acpx/-/acpx-1.0.1.tgz",
+        integrity: "sha512-test",
+      },
+    },
+  };
+}
+
+export function packageEntry(lock = packageLock()) {
+  return {
+    packageDir: "extensions/acpx", name: packageName, version,
+    bundleRuntimeDependencies: false, dependencyCount: 1, optionalDependencyCount: 0,
+    lockSha256: sha256(jsonText(lock)), lock,
+  };
+}
+
+export function evidenceReport(entry = packageEntry()) {
+  return {
+    schemaVersion: 1, generatedAt: "2026-09-06T12:00:00.000Z",
+    sourceSha: releaseRev, lockfileVersion: 3, packages: [entry],
+  };
+}
+
+export function evidenceDirectory(t, report = evidenceReport(), manifest = {}) {
+  const directory = tempDir(t);
+  fs.mkdirSync(path.join(directory, "dependency-evidence"));
+  writeJson(path.join(directory, "dependency-evidence/dependency-evidence-manifest.json"), {
+    releaseTag, releaseSha: releaseRev, ...manifest,
+  });
+  writeJson(path.join(directory, "dependency-evidence/npm-package-locks.json"), report);
+  return directory;
+}

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
@@ -156,10 +156,12 @@ export function verifyNpmPackageLockEvidenceAssets({
   }
 }
 
+// mkDerivation `env` only accepts strings, so interpolate the path: Nix copies
+// the file into the store and yields its store path as a string.
 export function renderPackageLockProbeEnv(packageLockFile) {
   if (!packageLockFile) return "";
   const escapedPath = JSON.stringify(packageLockFile).replaceAll("${", "\\${");
-  return `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + ${escapedPath};`;
+  return `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "\${/. + ${escapedPath}}";`;
 }
 
 // Keep original evidence bytes separate from the normalized build-time lock.

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
@@ -9,6 +9,10 @@ const evidenceDirName = "dependency-evidence";
 const manifestName = "dependency-evidence-manifest.json";
 const reportName = "npm-package-locks.json";
 
+class IncompletePackageLockEvidenceError extends Error {
+  code = "package-lock-evidence-incomplete";
+}
+
 function run(command, args) {
   const result = childProcess.spawnSync(command, args, {
     encoding: "utf8",
@@ -104,6 +108,14 @@ export function selectNpmPackageLock(evidence, packageName, version) {
   assert(entries.length === 1, `duplicate npm package-lock evidence for ${packageName}@${version}`);
   const [entry] = entries;
   assert(entry.bundleRuntimeDependencies === false, `npm package-lock evidence for ${packageName} is bundled`);
+  assert(Array.isArray(entry.omittedWorkspaceDependencies)
+    && entry.omittedWorkspaceDependencies.every((name) => typeof name === "string" && name.length > 0),
+  `npm package-lock evidence for ${packageName} omittedWorkspaceDependencies must be an array of dependency names`);
+  if (entry.omittedWorkspaceDependencies.length > 0) {
+    throw new IncompletePackageLockEvidenceError(
+      `npm package-lock evidence for ${packageName}@${version} omits workspace runtime dependencies: ${entry.omittedWorkspaceDependencies.join(", ")}`,
+    );
+  }
   const lock = entry.lock;
   assert(isRecord(lock) && lock.lockfileVersion === 3, "npm package-lock requires lockfileVersion 3");
   assert(isRecord(lock.packages), "npm package-lock packages must be an object");
@@ -177,7 +189,13 @@ export function createNpmPackageLockMaterializer({
       if (evidence === undefined) {
         evidence = loadEvidence({ releaseTag, releaseVersion, releaseRev });
       }
-      const selected = selectNpmPackageLock(evidence, artifact.packageName, artifact.version);
+      let selected;
+      try {
+        selected = selectNpmPackageLock(evidence, artifact.packageName, artifact.version);
+      } catch (error) {
+        if (error instanceof IncompletePackageLockEvidenceError) return onFailure(error.code, error);
+        throw error;
+      }
       if (!selected) return null;
       const { entry, lockText } = selected;
       const npmPackageLockFile = `${attrName}.package-lock.json`;

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
@@ -1,0 +1,168 @@
+import childProcess from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isUnsupportedResolvedSource } from "./openclaw-runtime-plugin-prepare-npm.mjs";
+
+const evidenceDirName = "dependency-evidence";
+const manifestName = "dependency-evidence-manifest.json";
+const reportName = "npm-package-locks.json";
+
+function run(command, args) {
+  const result = childProcess.spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed:\n${result.error ?? result.stderr ?? result.stdout}`);
+  }
+  return result.stdout;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function dependencyEvidenceAssetName(releaseVersion) {
+  return `openclaw-${releaseVersion}-dependency-evidence.zip`;
+}
+
+export function dependencyEvidenceAssetUrl({ releaseTag, releaseVersion }) {
+  return `https://github.com/openclaw/openclaw/releases/download/${releaseTag}/${dependencyEvidenceAssetName(releaseVersion)}`;
+}
+
+// directory is the extraction root, containing dependency-evidence/.
+export function parseNpmPackageLocksEvidence({ directory, releaseTag, releaseRev }) {
+  function readJson(name) {
+    const file = path.join(directory, evidenceDirName, name);
+    assert(fs.lstatSync(file).isFile(), `evidence ${name} must be a regular file`);
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  }
+  const manifest = readJson(manifestName);
+  assert(manifest.releaseTag === releaseTag, "dependency evidence releaseTag mismatch");
+  assert(manifest.releaseSha === releaseRev, "dependency evidence releaseSha mismatch");
+  // Older releases have dependency evidence without an npm lock report.
+  if (!fs.existsSync(path.join(directory, evidenceDirName, reportName))) return null;
+  const report = readJson(reportName);
+  assert(report.schemaVersion === 1, "unsupported npm package-lock evidence schemaVersion");
+  assert(report.sourceSha === releaseRev, "npm package-lock evidence sourceSha mismatch");
+  assert(report.lockfileVersion === 3, "npm package-lock evidence requires lockfileVersion 3");
+  assert(typeof report.generatedAt === "string" && Number.isFinite(Date.parse(report.generatedAt)),
+    "npm package-lock evidence has invalid generatedAt");
+  assert(Array.isArray(report.packages), "npm package-lock evidence packages must be an array");
+  return { sourceSha: report.sourceSha, generatedAt: report.generatedAt, packages: report.packages };
+}
+
+export function loadNpmPackageLocksEvidence({
+  releaseTag, releaseVersion, releaseRev,
+  overrideZipPath = process.env.OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_EVIDENCE_ZIP,
+}, { runCommand = run } = {}) {
+  const assetName = dependencyEvidenceAssetName(releaseVersion);
+  const assetUrl = dependencyEvidenceAssetUrl({ releaseTag, releaseVersion });
+  let zipPath = overrideZipPath && path.resolve(overrideZipPath);
+  let assetNixHash;
+  if (zipPath) {
+    assetNixHash = `sha256-${crypto.createHash("sha256").update(fs.readFileSync(zipPath)).digest("base64")}`;
+  } else {
+    let prefetch;
+    try {
+      prefetch = JSON.parse(runCommand("nix", ["store", "prefetch-file", "--json", assetUrl]));
+    } catch (error) {
+      if (/\b(?:HTTP(?: error)?\s+404|404\s+Not Found)\b/i.test(error.message)) return null;
+      throw error;
+    }
+    zipPath = prefetch.storePath;
+    assetNixHash = prefetch.hash;
+  }
+  assert(/^sha256-[A-Za-z0-9+/]{43}=$/.test(assetNixHash), "dependency evidence has invalid Nix hash");
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-npm-lock-evidence-"));
+  try {
+    const members = runCommand("unzip", ["-Z1", zipPath]).split(/\r?\n/);
+    const files = [manifestName, reportName].map((name) => `${evidenceDirName}/${name}`);
+    assert(members.includes(files[0]), "dependency evidence manifest is missing");
+    // Extract only the two contract files, never unrelated archive paths.
+    runCommand("unzip", ["-q", zipPath, ...files.filter((file) => members.includes(file)), "-d", directory]);
+    const report = parseNpmPackageLocksEvidence({ directory, releaseTag, releaseRev });
+    return report && {
+      assetName, assetUrl, assetNixHash, source: overrideZipPath ? "override" : "release", ...report,
+    };
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+export function selectNpmPackageLock(evidence, packageName, version) {
+  if (!evidence) return null;
+  const entries = evidence.packages.filter((entry) => entry.name === packageName && entry.version === version);
+  if (entries.length === 0) return null;
+  assert(entries.length === 1, `duplicate npm package-lock evidence for ${packageName}@${version}`);
+  const [entry] = entries;
+  assert(entry.bundleRuntimeDependencies === false, `npm package-lock evidence for ${packageName} is bundled`);
+  const lock = entry.lock;
+  assert(isRecord(lock) && lock.lockfileVersion === 3, "npm package-lock requires lockfileVersion 3");
+  assert(isRecord(lock.packages), "npm package-lock packages must be an object");
+  const root = lock.packages[""];
+  assert(root?.name === packageName && root?.version === version, "npm package-lock root name/version mismatch");
+  const lockText = `${JSON.stringify(lock, null, 2)}\n`;
+  assert(crypto.createHash("sha256").update(lockText).digest("hex") === entry.lockSha256,
+    `npm package-lock lockSha256 mismatch for ${packageName}`);
+  for (const [packagePath, pkg] of Object.entries(lock.packages)) {
+    assert(isRecord(pkg), `invalid npm package-lock entry ${packagePath}`);
+    assert(pkg.dev !== true, `npm package-lock contains dev package ${packagePath}`);
+    assert(pkg.link !== true, `npm package-lock contains linked package ${packagePath}`);
+    assert(typeof pkg.resolved !== "string" || !isUnsupportedResolvedSource(pkg.resolved),
+      `npm package-lock contains unsupported resolved source for ${packagePath}`);
+    if (packagePath !== "") {
+      assert(typeof pkg.resolved === "string" && pkg.resolved.length > 0
+        && typeof pkg.integrity === "string" && pkg.integrity.length > 0,
+      `npm package-lock entry ${packagePath} requires resolved and integrity`);
+    }
+  }
+  return { entry, lockText };
+}
+
+// Keep original evidence bytes separate from the normalized build-time lock.
+export function createNpmPackageLockMaterializer({
+  releaseTag, releaseVersion, releaseRev, prepare, computeNpmDepsHash,
+  loadEvidence = loadNpmPackageLocksEvidence,
+}) {
+  let evidence;
+  const generatedFiles = new Map();
+  return {
+    generatedFiles,
+    materialize({ artifact, packageRoot, attrName, probe, onFailure }) {
+      if (evidence === undefined) {
+        evidence = loadEvidence({ releaseTag, releaseVersion, releaseRev });
+      }
+      const selected = selectNpmPackageLock(evidence, artifact.packageName, artifact.version);
+      if (!selected) return null;
+      const { entry, lockText } = selected;
+      const npmPackageLockFile = `${attrName}.package-lock.json`;
+      const evidenceLockPath = path.join(packageRoot, "..", npmPackageLockFile);
+      fs.writeFileSync(evidenceLockPath, lockText);
+      let stage = "prepare";
+      let npmDepsHash;
+      try {
+        prepare(packageRoot, artifact, "package-lock", evidenceLockPath);
+        stage = "npm-deps-hash";
+        npmDepsHash = computeNpmDepsHash(path.join(packageRoot, "package-lock.json"));
+        stage = "materialization";
+        probe(npmDepsHash, evidenceLockPath);
+      } catch (error) {
+        return onFailure(`package-lock-${stage}-failed`, error);
+      }
+      generatedFiles.set(npmPackageLockFile, lockText);
+      const { packages, ...npmPackageLockEvidence } = evidence;
+      return {
+        dependencyMode: "package-lock", npmDepsHash, npmPackageLockFile,
+        npmPackageLockSha256: entry.lockSha256, npmPackageLockEvidence,
+      };
+    },
+  };
+}

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
@@ -127,6 +127,41 @@ export function selectNpmPackageLock(evidence, packageName, version) {
   return { entry, lockText };
 }
 
+export function verifyNpmPackageLockEvidenceAssets({
+  locks, generatedDir, sourceInfo,
+  verifyAssets = process.env.OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET === "1",
+}, { loadEvidence = loadNpmPackageLocksEvidence } = {}) {
+  if (!verifyAssets) return;
+  let publishedEvidence;
+  for (const lock of Object.values(locks)) {
+    if (lock.dependencyMode !== "package-lock" || lock.npmPackageLockEvidence.source !== "release") continue;
+    if (publishedEvidence === undefined) {
+      publishedEvidence = loadEvidence({
+        releaseTag: sourceInfo.releaseTag, releaseVersion: sourceInfo.releaseVersion,
+        releaseRev: sourceInfo.rev, overrideZipPath: "",
+      });
+    }
+    assert(publishedEvidence, "published npm package-lock evidence asset or report is missing");
+    const evidence = lock.npmPackageLockEvidence;
+    assert(publishedEvidence.source === "release", "package-lock provenance verification requires release evidence");
+    assert(publishedEvidence.assetUrl === evidence.assetUrl, `lock ${lock.id} published evidence assetUrl mismatch`);
+    assert(publishedEvidence.assetNixHash === evidence.assetNixHash,
+      `lock ${lock.id} published evidence assetNixHash mismatch`);
+    const selected = selectNpmPackageLock(publishedEvidence, lock.packageName, lock.version);
+    assert(selected, `published npm package-lock evidence is missing ${lock.packageName}@${lock.version}`);
+    assert(selected.entry.lockSha256 === lock.npmPackageLockSha256,
+      `lock ${lock.id} published evidence lockSha256 mismatch`);
+    assert(Buffer.from(selected.lockText, "utf8").equals(fs.readFileSync(path.join(generatedDir, lock.npmPackageLockFile))),
+      `lock ${lock.id} sidecar bytes differ from published npm package-lock evidence`);
+  }
+}
+
+export function renderPackageLockProbeEnv(packageLockFile) {
+  if (!packageLockFile) return "";
+  const escapedPath = JSON.stringify(packageLockFile).replaceAll("${", "\\${");
+  return `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + ${escapedPath};`;
+}
+
 // Keep original evidence bytes separate from the normalized build-time lock.
 export function createNpmPackageLockMaterializer({
   releaseTag, releaseVersion, releaseRev, prepare, computeNpmDepsHash,

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
@@ -26,7 +26,7 @@ test("probe evidence paths are quoted Nix paths even with spaces", () => {
 
 test("probe evidence paths escape quotes, backslashes, and Nix interpolation", () => {
   assert.equal(renderPackageLockProbeEnv('/tmp/a"b\\c/${value}/acpx.package-lock.json'),
-    String.raw`OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "${/. + "/tmp/a\"b\\c/\${value}/acpx.package-lock.json"}";`);
+    'OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "${/. + ' + String.raw`"/tmp/a\"b\\c/\${value}/acpx.package-lock.json"` + '}";');
 });
 
 test("parses evidence and selects the exact package with canonical lock bytes", (t) => {

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
@@ -20,13 +20,13 @@ test("asset identity uses release version, not the runtime plugin version", () =
 
 test("probe evidence paths are quoted Nix paths even with spaces", () => {
   assert.equal(renderPackageLockProbeEnv("/tmp/plugin evidence/acpx.package-lock.json"),
-    'OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + "/tmp/plugin evidence/acpx.package-lock.json";');
+    'OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "${/. + "/tmp/plugin evidence/acpx.package-lock.json"}";');
   assert.equal(renderPackageLockProbeEnv(""), "");
 });
 
 test("probe evidence paths escape quotes, backslashes, and Nix interpolation", () => {
   assert.equal(renderPackageLockProbeEnv('/tmp/a"b\\c/${value}/acpx.package-lock.json'),
-    String.raw`OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + "/tmp/a\"b\\c/\${value}/acpx.package-lock.json";`);
+    String.raw`OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "${/. + "/tmp/a\"b\\c/\${value}/acpx.package-lock.json"}";`);
 });
 
 test("parses evidence and selects the exact package with canonical lock bytes", (t) => {

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   dependencyEvidenceAssetName, dependencyEvidenceAssetUrl, parseNpmPackageLocksEvidence,
   selectNpmPackageLock, createNpmPackageLockMaterializer, loadNpmPackageLocksEvidence,
+  renderPackageLockProbeEnv,
 } from "./openclaw-runtime-plugin-package-locks.mjs";
 import {
   releaseTag, releaseVersion, releaseRev, packageName, version, sri,
@@ -15,6 +16,17 @@ test("asset identity uses release version, not the runtime plugin version", () =
   assert.equal(dependencyEvidenceAssetName(releaseVersion), "openclaw-2026.9.1-2-dependency-evidence.zip");
   assert.equal(dependencyEvidenceAssetUrl({ releaseTag, releaseVersion }),
     "https://github.com/openclaw/openclaw/releases/download/v2026.9.1-2/openclaw-2026.9.1-2-dependency-evidence.zip");
+});
+
+test("probe evidence paths are quoted Nix paths even with spaces", () => {
+  assert.equal(renderPackageLockProbeEnv("/tmp/plugin evidence/acpx.package-lock.json"),
+    'OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + "/tmp/plugin evidence/acpx.package-lock.json";');
+  assert.equal(renderPackageLockProbeEnv(""), "");
+});
+
+test("probe evidence paths escape quotes, backslashes, and Nix interpolation", () => {
+  assert.equal(renderPackageLockProbeEnv('/tmp/a"b\\c/${value}/acpx.package-lock.json'),
+    String.raw`OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = /. + "/tmp/a\"b\\c/\${value}/acpx.package-lock.json";`);
 });
 
 test("parses evidence and selects the exact package with canonical lock bytes", (t) => {

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
@@ -114,6 +114,60 @@ test("rejects a wrong lock digest or bundled entry", () => {
     packageName, version), /is bundled/);
 });
 
+test("accepts an explicitly empty omitted workspace dependency list", () => {
+  const evidence = evidenceReport();
+  assert.deepEqual(evidence.packages[0].omittedWorkspaceDependencies, []);
+  assert.equal(selectNpmPackageLock(evidence, packageName, version).lockText, jsonText(packageLock()));
+});
+
+test("missing or malformed omittedWorkspaceDependencies is a validation error, not a skip", () => {
+  for (const value of [undefined, null, "@openclaw/core", {}, [1]]) {
+    const entry = { ...packageEntry(), omittedWorkspaceDependencies: value };
+    if (value === undefined) delete entry.omittedWorkspaceDependencies;
+    const evidence = evidenceReport(entry);
+    const invalidField = (error) => {
+      assert.match(error.message, /omittedWorkspaceDependencies must be an array of dependency names/);
+      assert.equal(error.code, undefined);
+      return true;
+    };
+    assert.throws(() => selectNpmPackageLock(evidence, packageName, version), invalidField);
+    const materializer = createNpmPackageLockMaterializer({ loadEvidence: () => evidence });
+    assert.throws(() => materializer.materialize({
+      artifact: { packageName, version },
+      onFailure: () => assert.fail("invalid schema must not become a skip"),
+    }), invalidField);
+  }
+});
+
+test("partial evidence skips materialization with the distinct reason and omitted names", (t) => {
+  const omittedWorkspaceDependencies = ["@openclaw/core", "@openclaw/shared"];
+  const evidence = evidenceReport({ ...packageEntry(), omittedWorkspaceDependencies });
+  const reason = "package-lock-evidence-incomplete";
+  const detail = `npm package-lock evidence for ${packageName}@${version} omits workspace runtime dependencies: @openclaw/core, @openclaw/shared`;
+  assert.throws(() => selectNpmPackageLock(evidence, packageName, version), (error) => {
+    assert.equal(error.code, reason);
+    assert.equal(error.message, detail);
+    return true;
+  });
+  const materializer = createNpmPackageLockMaterializer({
+    loadEvidence: () => evidence,
+    prepare: () => assert.fail("partial locks must not be prepared"),
+    computeNpmDepsHash: () => assert.fail("partial locks must not be hashed"),
+  });
+  const directory = tempDir(t);
+  const packageRoot = path.join(directory, "package");
+  fs.mkdirSync(packageRoot);
+  const result = materializer.materialize({
+    artifact: { packageName, version }, packageRoot, attrName: "acpx",
+    probe: () => assert.fail("partial locks must not be probed"),
+    onFailure: (reason, error) => ({ skipped: { reason, detail: error.message } }),
+  });
+  assert.deepEqual(result, { skipped: { reason, detail } });
+  assert.equal(materializer.generatedFiles.size, 0);
+  assert.deepEqual(fs.readdirSync(directory), ["package"]);
+  assert.deepEqual(fs.readdirSync(packageRoot), []);
+});
+
 for (const [label, patch, pattern] of [
   ["dev", { dev: true }, /dev package/],
   ["link", { link: true }, /linked package/],

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  dependencyEvidenceAssetName, dependencyEvidenceAssetUrl, parseNpmPackageLocksEvidence,
+  selectNpmPackageLock, createNpmPackageLockMaterializer, loadNpmPackageLocksEvidence,
+} from "./openclaw-runtime-plugin-package-locks.mjs";
+import {
+  releaseTag, releaseVersion, releaseRev, packageName, version, sri,
+  jsonText, packageLock, packageEntry, evidenceReport, evidenceDirectory, tempDir,
+} from "./openclaw-runtime-plugin-package-locks.fixtures.mjs";
+
+test("asset identity uses release version, not the runtime plugin version", () => {
+  assert.equal(dependencyEvidenceAssetName(releaseVersion), "openclaw-2026.9.1-2-dependency-evidence.zip");
+  assert.equal(dependencyEvidenceAssetUrl({ releaseTag, releaseVersion }),
+    "https://github.com/openclaw/openclaw/releases/download/v2026.9.1-2/openclaw-2026.9.1-2-dependency-evidence.zip");
+});
+
+test("parses evidence and selects the exact package with canonical lock bytes", (t) => {
+  const directory = evidenceDirectory(t);
+  const evidence = parseNpmPackageLocksEvidence({ directory, releaseTag, releaseRev });
+  const selected = selectNpmPackageLock(evidence, packageName, version);
+  assert.deepEqual(selected.entry, packageEntry());
+  assert.equal(selected.lockText, jsonText(packageLock()));
+  assert.equal(evidence.sourceSha, releaseRev);
+  assert.equal(evidence.generatedAt, "2026-09-06T12:00:00.000Z");
+  assert.equal(selectNpmPackageLock(evidence, "@openclaw/missing", version), null);
+  assert.equal(selectNpmPackageLock(evidence, packageName, releaseVersion), null);
+  assert.equal(selectNpmPackageLock(null, packageName, version), null);
+});
+
+for (const [label, reportPatch, manifestPatch, pattern] of [
+  ["sourceSha", { sourceSha: "b".repeat(40) }, {}, /sourceSha mismatch/],
+  ["releaseSha", {}, { releaseSha: "b".repeat(40) }, /releaseSha mismatch/],
+  ["releaseTag", {}, { releaseTag: "v2026.8.1" }, /releaseTag mismatch/],
+  ["schemaVersion", { schemaVersion: 2 }, {}, /schemaVersion/],
+  ["lockfileVersion", { lockfileVersion: 2 }, {}, /lockfileVersion/],
+]) {
+  test(`rejects wrong evidence ${label}`, (t) => {
+    const directory = evidenceDirectory(t, { ...evidenceReport(), ...reportPatch }, manifestPatch);
+    assert.throws(() => parseNpmPackageLocksEvidence({ directory, releaseTag, releaseRev }), pattern);
+  });
+}
+
+test("old release evidence without an npm report returns null", (t) => {
+  const directory = evidenceDirectory(t);
+  fs.unlinkSync(path.join(directory, "dependency-evidence/npm-package-locks.json"));
+  assert.equal(parseNpmPackageLocksEvidence({ directory, releaseTag, releaseRev }), null);
+});
+
+test("loader treats only missing release assets as absent evidence", () => {
+  for (const message of ["HTTP error 404", "HTTP 404 Not Found", "404 Not Found"]) {
+    assert.equal(loadNpmPackageLocksEvidence({ releaseTag, releaseVersion, releaseRev, overrideZipPath: "" }, {
+      runCommand: () => { throw new Error(message); },
+    }), null);
+  }
+  assert.throws(() => loadNpmPackageLocksEvidence({ releaseTag, releaseVersion, releaseRev, overrideZipPath: "" }, {
+    runCommand: () => { throw new Error("HTTP error 503"); },
+  }), /503/);
+});
+
+for (const source of ["release", "override"]) {
+  test(`loader records ${source} provenance and cleans extraction directory`, (t) => {
+    const fixture = evidenceDirectory(t);
+    const zipPath = path.join(tempDir(t), "evidence.zip");
+    fs.writeFileSync(zipPath, Buffer.alloc(0));
+    let extracted;
+    let prefetches = 0;
+    const evidence = loadNpmPackageLocksEvidence({
+      releaseTag, releaseVersion, releaseRev, overrideZipPath: source === "override" ? zipPath : "",
+    }, { runCommand: (command, args) => {
+      if (command === "nix") {
+        prefetches += 1;
+        assert.deepEqual(args, ["store", "prefetch-file", "--json", dependencyEvidenceAssetUrl({ releaseTag, releaseVersion })]);
+        return JSON.stringify({ storePath: zipPath, hash: sri });
+      }
+      assert.equal(command, "unzip");
+      assert.equal(args[1], zipPath);
+      if (args[0] === "-Z1") {
+        return "dependency-evidence/dependency-evidence-manifest.json\ndependency-evidence/npm-package-locks.json\nunrelated\n";
+      }
+      assert.deepEqual(args.slice(0, -1), ["-q", zipPath,
+        "dependency-evidence/dependency-evidence-manifest.json", "dependency-evidence/npm-package-locks.json", "-d"]);
+      extracted = args.at(-1);
+      fs.cpSync(path.join(fixture, "dependency-evidence"), path.join(extracted, "dependency-evidence"), { recursive: true });
+      return "";
+    } });
+    assert.equal(evidence.source, source);
+    assert.equal(evidence.sourceSha, releaseRev);
+    assert.equal(evidence.assetNixHash, source === "override"
+      ? "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=" : sri);
+    assert.equal(prefetches, source === "override" ? 0 : 1);
+    assert.equal(fs.existsSync(extracted), false);
+  });
+}
+
+test("rejects a wrong lock digest or bundled entry", () => {
+  assert.throws(() => selectNpmPackageLock(evidenceReport({ ...packageEntry(), lockSha256: "bad" }),
+    packageName, version), /lockSha256 mismatch/);
+  assert.throws(() => selectNpmPackageLock(evidenceReport({ ...packageEntry(), bundleRuntimeDependencies: true }),
+    packageName, version), /is bundled/);
+});
+
+for (const [label, patch, pattern] of [
+  ["dev", { dev: true }, /dev package/],
+  ["link", { link: true }, /linked package/],
+  ["missing resolved", { resolved: undefined }, /requires resolved and integrity/],
+  ["missing integrity", { integrity: undefined }, /requires resolved and integrity/],
+  ...["file:local", "workspace:*", "git+https://example.com/repo", "git:repo", "ssh:repo",
+    "https://github.com/example/repo"].map((resolved) => [resolved, { resolved }, /unsupported resolved/]),
+]) {
+  test(`rejects ${label} in package lock`, () => {
+    const lock = packageLock();
+    Object.assign(lock.packages["node_modules/acpx"], patch);
+    assert.throws(() => selectNpmPackageLock(evidenceReport(packageEntry(lock)), packageName, version), pattern);
+  });
+}
+
+for (const field of ["name", "version"]) {
+  test(`rejects wrong root ${field}`, () => {
+    const lock = packageLock();
+    lock.packages[""][field] = "wrong";
+    assert.throws(() => selectNpmPackageLock(evidenceReport(packageEntry(lock)), packageName, version), /root name\/version/);
+  });
+}
+
+test("rejects dev/link flags on the root too", () => {
+  for (const field of ["dev", "link"]) {
+    const lock = packageLock();
+    lock.packages[""][field] = true;
+    assert.throws(() => selectNpmPackageLock(evidenceReport(packageEntry(lock)), packageName, version), /contains/);
+  }
+});
+
+test("materializer loads once, hashes prepared bytes, and retains original generated bytes", (t) => {
+  let loads = 0;
+  const evidence = { ...evidenceReport(), assetName: dependencyEvidenceAssetName(releaseVersion),
+    assetUrl: dependencyEvidenceAssetUrl({ releaseTag, releaseVersion }), assetNixHash: sri, source: "release" };
+  const materializer = createNpmPackageLockMaterializer({
+    releaseTag, releaseVersion, releaseRev,
+    loadEvidence: (options) => {
+      assert.deepEqual(options, { releaseTag, releaseVersion, releaseRev });
+      loads += 1;
+      return evidence;
+    },
+    prepare: (root, artifact, mode, file) => {
+      assert.equal(mode, "package-lock");
+      assert.equal(fs.readFileSync(file, "utf8"), jsonText(packageLock()));
+      const lock = JSON.parse(fs.readFileSync(file, "utf8"));
+      lock.packages[""].dependencies.acpx = "1.0.1";
+      fs.writeFileSync(path.join(root, "package-lock.json"), jsonText(lock));
+    },
+    computeNpmDepsHash: (file) => {
+      assert.equal(JSON.parse(fs.readFileSync(file)).packages[""].dependencies.acpx, "1.0.1");
+      return sri;
+    },
+  });
+  const root = path.join(tempDir(t), "package");
+  fs.mkdirSync(root);
+  const artifact = { packageName, version };
+  let probes = 0;
+  const result = materializer.materialize({
+    artifact, packageRoot: root, attrName: "acpx",
+    probe: (hash, file) => {
+      probes += 1;
+      assert.equal(hash, sri);
+      assert.equal(fs.readFileSync(file, "utf8"), jsonText(packageLock()));
+    },
+    onFailure: (reason, error) => { throw error; },
+  });
+  assert.equal(result.dependencyMode, "package-lock");
+  assert.equal(result.npmPackageLockSha256, packageEntry().lockSha256);
+  assert.equal(result.npmPackageLockFile, "acpx.package-lock.json");
+  assert.equal(result.npmPackageLockEvidence.sourceSha, releaseRev);
+  assert.equal("packages" in result.npmPackageLockEvidence, false);
+  assert.equal(materializer.generatedFiles.get("acpx.package-lock.json"), jsonText(packageLock()));
+  assert.equal(materializer.materialize({ artifact: { ...artifact, version: "missing" } }), null);
+  assert.equal(loads, 1);
+  assert.equal(probes, 1);
+});
+
+test("materializer caches absent evidence too", () => {
+  let loads = 0;
+  const materializer = createNpmPackageLockMaterializer({ loadEvidence: () => { loads += 1; return null; } });
+  for (let i = 0; i < 2; i += 1) {
+    assert.equal(materializer.materialize({ artifact: { packageName, version } }), null);
+  }
+  assert.equal(loads, 1);
+  assert.equal(materializer.generatedFiles.size, 0);
+});
+
+for (const stage of ["prepare", "npm-deps-hash", "materialization"]) {
+  test(`failed ${stage} does not emit a generated sidecar`, (t) => {
+    const root = path.join(tempDir(t), "package");
+    fs.mkdirSync(root);
+    const fail = () => { throw new Error("probe failed"); };
+    const materializer = createNpmPackageLockMaterializer({
+      loadEvidence: () => evidenceReport(),
+      prepare: stage === "prepare" ? fail : () => {},
+      computeNpmDepsHash: stage === "npm-deps-hash" ? fail : () => sri,
+    });
+    const result = materializer.materialize({
+      artifact: { packageName, version }, packageRoot: root, attrName: "acpx",
+      probe: stage === "materialization" ? fail : () => {},
+      onFailure: (reason, error) => ({ reason, message: error.message }),
+    });
+    assert.deepEqual(result, { reason: `package-lock-${stage}-failed`, message: "probe failed" });
+    assert.equal(materializer.generatedFiles.size, 0);
+  });
+}

--- a/nix/scripts/openclaw-runtime-plugin-prepare-npm.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-prepare-npm.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -25,15 +26,15 @@ function fail(message) {
   throw new Error(message);
 }
 
-function isUnsupportedResolvedSource(resolved) {
+export function isUnsupportedResolvedSource(resolved) {
   return /^(file:|workspace:|git\+|git:|ssh:|https:\/\/github\.com\/)/.test(resolved);
 }
 
-function dependencyPackagePath(parentPath, dependencyName) {
+function dependencyPackagePath(lock, parentPath, dependencyName) {
   let current = parentPath;
   while (true) {
     const candidate = `${current ? `${current}/` : ""}node_modules/${dependencyName}`;
-    if (shrinkwrap.packages?.[candidate]) {
+    if (lock.packages?.[candidate]) {
       return candidate;
     }
     if (!current) {
@@ -52,17 +53,17 @@ function dependencyPackagePath(parentPath, dependencyName) {
   }
 }
 
-function normalizeLockedDependencySpecs() {
+export function normalizeLockedDependencySpecs(lock) {
   let changed = false;
-  for (const [packagePath, entry] of Object.entries(shrinkwrap.packages ?? {})) {
+  for (const [packagePath, entry] of Object.entries(lock.packages ?? {})) {
     for (const field of ["dependencies", "optionalDependencies"]) {
       const dependencies = entry[field];
       if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) {
         continue;
       }
       for (const dependencyName of Object.keys(dependencies).sort()) {
-        const resolvedPath = dependencyPackagePath(packagePath, dependencyName);
-        const lockedVersion = resolvedPath ? shrinkwrap.packages?.[resolvedPath]?.version : null;
+        const resolvedPath = dependencyPackagePath(lock, packagePath, dependencyName);
+        const lockedVersion = resolvedPath ? lock.packages?.[resolvedPath]?.version : null;
         if (!lockedVersion || dependencies[dependencyName] === lockedVersion) {
           continue;
         }
@@ -74,64 +75,80 @@ function normalizeLockedDependencySpecs() {
   return changed;
 }
 
-const dependencyMode = requiredEnv("OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE");
-if (dependencyMode !== "shrinkwrap") {
-  process.exit(0);
-}
-
-const packageJsonPath = path.resolve("package.json");
-const shrinkwrapPath = path.resolve("npm-shrinkwrap.json");
-
-if (!fs.existsSync(packageJsonPath)) {
-  fail("package.json missing from shrinkwrapped runtime plugin package root");
-}
-if (!fs.existsSync(shrinkwrapPath)) {
-  fail("npm-shrinkwrap.json missing from shrinkwrapped runtime plugin package root");
-}
-
-const packageJson = readJson(packageJsonPath);
-const shrinkwrap = readJson(shrinkwrapPath);
-const rootLock = shrinkwrap.packages?.[""];
-const expectedPackageName = optionalEnv("OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME") || packageJson.name;
-const expectedVersion = optionalEnv("OPENCLAW_RUNTIME_PLUGIN_VERSION") || packageJson.version;
-
-if (packageJson.name !== expectedPackageName) {
-  fail(`package name mismatch: expected ${expectedPackageName}, got ${packageJson.name}`);
-}
-if (packageJson.version !== expectedVersion) {
-  fail(`package version mismatch: expected ${expectedVersion}, got ${packageJson.version}`);
-}
-if (![2, 3].includes(shrinkwrap.lockfileVersion)) {
-  fail(`unsupported npm-shrinkwrap.json lockfileVersion ${shrinkwrap.lockfileVersion}`);
-}
-if (rootLock?.name && rootLock.name !== expectedPackageName) {
-  fail(`shrinkwrap root name mismatch: expected ${expectedPackageName}, got ${rootLock.name}`);
-}
-if (rootLock?.version && rootLock.version !== expectedVersion) {
-  fail(`shrinkwrap root version mismatch: expected ${expectedVersion}, got ${rootLock.version}`);
-}
-
-for (const [packagePath, entry] of Object.entries(shrinkwrap.packages ?? {})) {
-  if (packagePath === "") {
-    continue;
+function prepare() {
+  const dependencyMode = requiredEnv("OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE");
+  if (!["shrinkwrap", "package-lock"].includes(dependencyMode)) {
+    return;
   }
-  if (entry.dev === true) {
-    fail(`shrinkwrap contains dev package ${packagePath}`);
+
+  const packageJsonPath = path.resolve("package.json");
+  const lockName = dependencyMode === "package-lock" ? "package-lock.json" : "npm-shrinkwrap.json";
+  const lockPath = path.resolve(lockName);
+  if (!fs.existsSync(packageJsonPath)) {
+    fail(`package.json missing from ${dependencyMode} runtime plugin package root`);
   }
-  if (entry.link === true) {
-    fail(`shrinkwrap contains linked package ${packagePath}`);
+  if (dependencyMode === "package-lock") {
+    const evidenceLock = requiredEnv("OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE");
+    for (const existing of ["package-lock.json", "npm-shrinkwrap.json"]) {
+      if (fs.existsSync(existing)) {
+        fail(`cannot inject package-lock evidence: package already contains ${existing}`);
+      }
+    }
+    fs.copyFileSync(evidenceLock, lockPath);
+    // Nix store inputs are read-only; the build copy must allow normalization.
+    fs.chmodSync(lockPath, 0o644);
   }
-  if (typeof entry.resolved === "string" && isUnsupportedResolvedSource(entry.resolved)) {
-    fail(`shrinkwrap contains unsupported resolved source for ${packagePath}: ${entry.resolved}`);
+  if (!fs.existsSync(lockPath)) {
+    fail(`${lockName} missing from ${dependencyMode} runtime plugin package root`);
+  }
+
+  const packageJson = readJson(packageJsonPath);
+  const lock = readJson(lockPath);
+  const rootLock = lock.packages?.[""];
+  const expectedPackageName = optionalEnv("OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME") || packageJson.name;
+  const expectedVersion = optionalEnv("OPENCLAW_RUNTIME_PLUGIN_VERSION") || packageJson.version;
+
+  if (packageJson.name !== expectedPackageName) {
+    fail(`package name mismatch: expected ${expectedPackageName}, got ${packageJson.name}`);
+  }
+  if (packageJson.version !== expectedVersion) {
+    fail(`package version mismatch: expected ${expectedVersion}, got ${packageJson.version}`);
+  }
+  if (![2, 3].includes(lock.lockfileVersion)) {
+    fail(`unsupported ${lockName} lockfileVersion ${lock.lockfileVersion}`);
+  }
+  if (rootLock?.name && rootLock.name !== expectedPackageName) {
+    fail(`${dependencyMode} root name mismatch: expected ${expectedPackageName}, got ${rootLock.name}`);
+  }
+  if (rootLock?.version && rootLock.version !== expectedVersion) {
+    fail(`${dependencyMode} root version mismatch: expected ${expectedVersion}, got ${rootLock.version}`);
+  }
+
+  for (const [packagePath, entry] of Object.entries(lock.packages ?? {})) {
+    if (packagePath === "") {
+      continue;
+    }
+    if (entry.dev === true) {
+      fail(`${dependencyMode} contains dev package ${packagePath}`);
+    }
+    if (entry.link === true) {
+      fail(`${dependencyMode} contains linked package ${packagePath}`);
+    }
+    if (typeof entry.resolved === "string" && isUnsupportedResolvedSource(entry.resolved)) {
+      fail(`${dependencyMode} contains unsupported resolved source for ${packagePath}: ${entry.resolved}`);
+    }
+  }
+
+  const lockChanged = normalizeLockedDependencySpecs(lock);
+  if (packageJson.devDependencies) {
+    delete packageJson.devDependencies;
+    writeJson(packageJsonPath, packageJson);
+  }
+  if (lockChanged) {
+    writeJson(lockPath, lock);
   }
 }
 
-const shrinkwrapChanged = normalizeLockedDependencySpecs();
-
-if (packageJson.devDependencies) {
-  delete packageJson.devDependencies;
-  writeJson(packageJsonPath, packageJson);
-}
-if (shrinkwrapChanged) {
-  writeJson(shrinkwrapPath, shrinkwrap);
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  prepare();
 }

--- a/nix/scripts/openclaw-runtime-plugin-prepare-npm.test.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-prepare-npm.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  packageName, version, jsonText, packageLock, tempDir, writeJson,
+} from "./openclaw-runtime-plugin-package-locks.fixtures.mjs";
+
+const script = fileURLToPath(new URL("./openclaw-runtime-plugin-prepare-npm.mjs", import.meta.url));
+
+function fixture(t, mode = "package-lock") {
+  const directory = tempDir(t);
+  const root = path.join(directory, "package");
+  fs.mkdirSync(root);
+  const lock = packageLock();
+  lock.packages["node_modules/acpx"].optionalDependencies = { helper: "^2.0.0" };
+  lock.packages["node_modules/acpx/node_modules/helper"] = {
+    version: "2.1.0", resolved: "https://registry.npmjs.org/helper/-/helper-2.1.0.tgz", integrity: "sha512-test",
+  };
+  const packageJson = { ...lock.packages[""], devDependencies: { test: "^1.0.0" } };
+  const file = path.join(directory, "evidence.package-lock.json");
+  writeJson(path.join(root, "package.json"), packageJson);
+  writeJson(file, lock);
+  fs.chmodSync(file, 0o444);
+  if (mode === "shrinkwrap") writeJson(path.join(root, "npm-shrinkwrap.json"), lock);
+  const env = {
+    ...process.env, OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE: mode,
+    OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE: file,
+    OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME: packageName, OPENCLAW_RUNTIME_PLUGIN_VERSION: version,
+  };
+  return { root, file, lock, env,
+    run: (extraEnv = {}) => spawnSync(process.execPath, [script], {
+      cwd: root, env: { ...env, ...extraEnv }, encoding: "utf8",
+    }),
+  };
+}
+
+for (const mode of ["package-lock", "shrinkwrap"]) {
+  test(`${mode} prepares exact dependency specs and strips devDependencies`, (t) => {
+    const { root, file, lock, run } = fixture(t, mode);
+    const result = run();
+    assert.equal(result.status, 0, result.stderr);
+    const lockName = mode === "package-lock" ? "package-lock.json" : "npm-shrinkwrap.json";
+    const prepared = JSON.parse(fs.readFileSync(path.join(root, lockName)));
+    const expected = structuredClone(lock);
+    expected.packages[""].dependencies.acpx = "1.0.1";
+    expected.packages["node_modules/acpx"].optionalDependencies.helper = "2.1.0";
+    assert.deepEqual(prepared, expected);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(root, "package.json"))).devDependencies, undefined);
+    assert.equal(fs.readFileSync(file, "utf8"), jsonText(lock));
+    assert.equal(fs.existsSync(path.join(root, mode === "package-lock" ? "npm-shrinkwrap.json" : "package-lock.json")), false);
+  });
+}
+
+for (const existing of ["package-lock.json", "npm-shrinkwrap.json"]) {
+  test(`package-lock injection rejects pre-existing ${existing} without overwriting`, (t) => {
+    const { root, run } = fixture(t);
+    const target = path.join(root, existing);
+    fs.writeFileSync(target, "existing lock\n");
+    const result = run();
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /package already contains/);
+    assert.equal(fs.readFileSync(target, "utf8"), "existing lock\n");
+  });
+}
+
+test("package-lock mode requires evidence file env", (t) => {
+  const result = fixture(t).run({ OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE: "" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE is required/);
+});
+
+for (const [label, mutate, pattern] of [
+  ["version", (lock) => { lock.packages[""].version = "wrong"; }, /root version mismatch/],
+  ["name", (lock) => { lock.packages[""].name = "wrong"; }, /root name mismatch/],
+  ["lockfile version", (lock) => { lock.lockfileVersion = 1; }, /unsupported package-lock.json lockfileVersion/],
+  ["dev", (lock) => { lock.packages["node_modules/acpx"].dev = true; }, /contains dev package/],
+  ["link", (lock) => { lock.packages["node_modules/acpx"].link = true; }, /contains linked package/],
+  ["resolved", (lock) => { lock.packages["node_modules/acpx"].resolved = "workspace:*"; }, /unsupported resolved/],
+]) {
+  test(`package-lock preparation rejects invalid ${label}`, (t) => {
+    const { lock, file, run } = fixture(t);
+    mutate(lock);
+    fs.chmodSync(file, 0o644);
+    writeJson(file, lock);
+    const result = run();
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, pattern);
+  });
+}

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createNpmPackageLockMaterializer } from "./openclaw-runtime-plugin-package-locks.mjs";
 import {
   defaultCatalogVersion,
   resolveRuntimePluginVersion,
@@ -657,19 +658,22 @@ function computeNpmDepsHash(shrinkwrapPath) {
   return hash;
 }
 
-function prepareShrinkwrappedPackage(packageRoot, artifact) {
+function prepareLockedPackage(packageRoot, artifact, dependencyMode = "shrinkwrap", packageLockFile = "") {
   run(process.execPath, [prepareNpmScriptPath], {
     cwd: packageRoot,
     env: {
       ...process.env,
-      OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE: "shrinkwrap",
+      OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE: dependencyMode,
+      OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE: packageLockFile,
       OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME: artifact.packageName,
       OPENCLAW_RUNTIME_PLUGIN_VERSION: artifact.version,
     },
   });
 }
 
-function probeShrinkwrapMaterialization(row, artifact, npmDepsHash) {
+function probeLockMaterialization(row, artifact, npmDepsHash, dependencyMode = "shrinkwrap", packageLockFile = "") {
+  const packageLockEnv = packageLockFile
+    ? `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = ${packageLockFile};` : "";
   const safeProbeName = attrNameForId(row.id);
   const expr = `
     let
@@ -700,7 +704,8 @@ function probeShrinkwrapMaterialization(row, artifact, npmDepsHash) {
           sourceRoot = "package";
           hash = ${nixString(npmDepsHash)};
           nativeBuildInputs = [ pkgs.nodejs_22 ];
-          OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = "shrinkwrap";
+          OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = ${nixString(dependencyMode)};
+          ${packageLockEnv}
           OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME = ${nixString(artifact.packageName)};
           OPENCLAW_RUNTIME_PLUGIN_VERSION = ${nixString(artifact.version)};
           postPatch = ''
@@ -719,14 +724,15 @@ function probeShrinkwrapMaterialization(row, artifact, npmDepsHash) {
           OPENCLAW_RUNTIME_PLUGIN_ID = ${nixString(row.id)};
           OPENCLAW_RUNTIME_PLUGIN_PACKAGE_NAME = ${nixString(artifact.packageName)};
           OPENCLAW_RUNTIME_PLUGIN_VERSION = ${nixString(artifact.version)};
-          OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = "shrinkwrap";
+          OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_MODE = ${nixString(dependencyMode)};
+          ${packageLockEnv}
         };
         postPatch = ''
           ${"\${pkgs.nodejs_22}"}/bin/node ${"\${prepareNpmScript}"}
         '';
         installPhase = ''
           mkdir -p "$out"
-          cp package.json npm-shrinkwrap.json "$out"/
+          cp package.json ${dependencyMode === "package-lock" ? "package-lock.json" : "npm-shrinkwrap.json"} "$out"/
         '';
       }
   `;
@@ -757,6 +763,7 @@ function desiredGeneratedFiles(locks, report) {
       path.join(outputDir, `${lock.attrName}.nix`),
       renderLock(lock),
     ]),
+    ...[...packageLocks.generatedFiles].map(([file, text]) => [path.join(outputDir, file), text]),
     [defaultOutputPath, renderDefault(locks)],
     [reportOutputPath, stableJson(report)],
   ]);
@@ -768,7 +775,7 @@ function existingGeneratedFiles() {
   }
   return fs
     .readdirSync(outputDir)
-    .filter((entry) => entry === "report.json" || entry.endsWith(".nix"))
+    .filter((entry) => entry === "report.json" || entry.endsWith(".nix") || entry.endsWith(".package-lock.json"))
     .map((entry) => path.join(outputDir, entry));
 }
 
@@ -1067,18 +1074,24 @@ function dependencyModeForArtifact(
   }
 
   if (!shrinkwrap) {
+    const result = packageLocks.materialize({
+      artifact, packageRoot, attrName: attrNameForId(row.id),
+      probe: (hash, lockFile) => probeLockMaterialization(row, artifact, hash, "package-lock", lockFile),
+      onFailure: (reason, error) => ({ skipped: skip(row, reason, briefError(error)) }),
+    });
+    if (result) return result;
     return {
       skipped: skip(
         row,
         "runtime-dependencies-without-shrinkwrap",
-        "package has runtime dependencies but no npm-shrinkwrap.json or bundled node_modules",
+        "package has runtime dependencies but no npm-shrinkwrap.json, bundled node_modules, or upstream npm package-lock evidence",
       ),
     };
   }
 
   const shrinkwrapPath = path.join(packageRoot, "npm-shrinkwrap.json");
   try {
-    prepareShrinkwrappedPackage(packageRoot, artifact);
+    prepareLockedPackage(packageRoot, artifact);
   } catch (error) {
     return {
       skipped: skip(row, "shrinkwrap-prepare-failed", briefError(error)),
@@ -1095,7 +1108,7 @@ function dependencyModeForArtifact(
   }
 
   try {
-    probeShrinkwrapMaterialization(row, artifact, npmDepsHash);
+    probeLockMaterialization(row, artifact, npmDepsHash);
   } catch (error) {
     return {
       skipped: skip(row, "shrinkwrap-materialization-failed", briefError(error)),
@@ -1218,8 +1231,7 @@ async function buildArtifactLock(row, artifact) {
       npmIntegrity: artifact.npmIntegrity,
       npmShasum: artifact.npmShasum,
       nixHash: artifact.nixHash,
-      dependencyMode: dependencyResult.dependencyMode,
-      npmDepsHash: dependencyResult.npmDepsHash,
+      ...dependencyResult,
       manifestId: manifest.id,
       openclawCompat,
       peerOpenClaw,
@@ -1305,6 +1317,10 @@ const runtimePluginVersion = readSourceField("runtimePluginVersion");
 const releaseTag = readSourceField("releaseTag");
 const pinnedRev = readSourceField("rev");
 const pinnedHash = readSourceField("hash");
+const packageLocks = createNpmPackageLockMaterializer({
+  releaseTag, releaseVersion, releaseRev: pinnedRev,
+  prepare: prepareLockedPackage, computeNpmDepsHash,
+});
 const openclawSourcePath = resolveOpenClawSourcePath();
 const taggedPackageVersion = JSON.parse(
   fs.readFileSync(path.join(openclawSourcePath, "package.json"), "utf8"),

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -7,7 +7,9 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { createNpmPackageLockMaterializer } from "./openclaw-runtime-plugin-package-locks.mjs";
+import {
+  createNpmPackageLockMaterializer, renderPackageLockProbeEnv,
+} from "./openclaw-runtime-plugin-package-locks.mjs";
 import {
   defaultCatalogVersion,
   resolveRuntimePluginVersion,
@@ -672,8 +674,7 @@ function prepareLockedPackage(packageRoot, artifact, dependencyMode = "shrinkwra
 }
 
 function probeLockMaterialization(row, artifact, npmDepsHash, dependencyMode = "shrinkwrap", packageLockFile = "") {
-  const packageLockEnv = packageLockFile
-    ? `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = ${packageLockFile};` : "";
+  const packageLockEnv = renderPackageLockProbeEnv(packageLockFile);
   const safeProbeName = attrNameForId(row.id);
   const expr = `
     let

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -1078,7 +1078,10 @@ function dependencyModeForArtifact(
     const result = packageLocks.materialize({
       artifact, packageRoot, attrName: attrNameForId(row.id),
       probe: (hash, lockFile) => probeLockMaterialization(row, artifact, hash, "package-lock", lockFile),
-      onFailure: (reason, error) => ({ skipped: skip(row, reason, briefError(error)) }),
+      onFailure: (reason, error) => ({
+        skipped: skip(row, reason,
+          reason === "package-lock-evidence-incomplete" ? error.message : briefError(error)),
+      }),
     });
     if (result) return result;
     return {

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -105,6 +105,20 @@ refresh_runtime_plugin_locks() {
   nix shell --extra-experimental-features "nix-command flakes" --accept-flake-config --inputs-from "$repo_root" \
     nixpkgs#nodejs_22 nixpkgs#unzip -c \
     node "$repo_root/nix/scripts/update-openclaw-runtime-plugin-locks.mjs"
+  track_new_runtime_plugin_locks
+}
+
+# Flake builds later in apply (gateway, plugin probes) copy only Git-tracked
+# files, so freshly generated lock sidecars must be registered with the index
+# before the first build reads them. The workflow repeats this for all pin files.
+track_new_runtime_plugin_locks() {
+  local -a new_files=()
+  while IFS= read -r file; do
+    new_files+=("$file")
+  done < <(git -C "$repo_root" ls-files --others --exclude-standard -- "$runtime_plugin_lock_rel_dir")
+  if [[ ${#new_files[@]} -gt 0 ]]; then
+    git -C "$repo_root" add --intent-to-add -- "${new_files[@]}"
+  fi
 }
 
 validate_runtime_plugin_locks() {

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -63,7 +63,7 @@ pin_file_paths() {
   {
     git -C "$repo_root" ls-files -- "$runtime_plugin_lock_rel_dir"
     if [[ -d "$runtime_plugin_lock_dir" ]]; then
-      find "$runtime_plugin_lock_dir" -maxdepth 1 -type f \( -name '*.nix' -o -name 'report.json' \) -print \
+      find "$runtime_plugin_lock_dir" -maxdepth 1 -type f \( -name '*.nix' -o -name '*.package-lock.json' -o -name 'report.json' \) -print \
         | sed "s|^$repo_root/||"
     fi
   } | sort -u
@@ -103,7 +103,7 @@ refresh_npm_wrapper_locks() {
 
 refresh_runtime_plugin_locks() {
   nix shell --extra-experimental-features "nix-command flakes" --accept-flake-config --inputs-from "$repo_root" \
-    nixpkgs#nodejs_22 -c \
+    nixpkgs#nodejs_22 nixpkgs#unzip -c \
     node "$repo_root/nix/scripts/update-openclaw-runtime-plugin-locks.mjs"
 }
 

--- a/scripts/update-pins.sh
+++ b/scripts/update-pins.sh
@@ -117,6 +117,9 @@ validate_runtime_plugin_locks() {
   if ! OPENCLAW_RUNTIME_PLUGIN_LOCK_DIR="$runtime_plugin_lock_dir" \
     OPENCLAW_RUNTIME_PLUGIN_LOCKS_JSON="$locks_json" \
     OPENCLAW_SOURCE_INFO_PATH="$source_file" \
+    OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET=1 \
+    nix shell --extra-experimental-features "nix-command flakes" --accept-flake-config --inputs-from "$repo_root" \
+    nixpkgs#nodejs_22 nixpkgs#unzip -c \
     node "$repo_root/nix/scripts/check-openclaw-runtime-plugin-locks.mjs"; then
     rm -f "$locks_json"
     return 1


### PR DESCRIPTION
## Problem

Since OpenClaw 2026.8.1 the `@openclaw/acpx` plugin (and six other `bundleRuntimeDependencies: false` plugins: codex, copilot, memory-lancedb, msteams, tlon, twitch) declares runtime dependencies but ships neither `npm-shrinkwrap.json` nor bundled `node_modules`, because npm 12 removed shrinkwrap support (openclaw/openclaw#114006). The stable-pin updater skips them as `runtime-dependencies-without-shrinkwrap`, the lock checker fails with `previously supported id acpx disappeared`, and the pin has been stuck on 2026.7.1-2 (every hourly "Pin Stable OpenClaw Version" run since 2026-09-04 is red).

## Solution

Consume the npm package-lock release evidence OpenClaw is adding per openclaw/openclaw#134190: `dependency-evidence/npm-package-locks.json` inside the existing `openclaw-<version>-dependency-evidence.zip` release asset.

- New `dependencyMode = "package-lock"` next to `shrinkwrap` and `bundled`. The updater downloads the pinned release's evidence asset, verifies release tag and source SHA, selects the exact `name@version`, and writes a byte-identical `<attr>.package-lock.json` sidecar next to the generated `.nix` lock. Evidence bytes are preserved; only build copies are normalized (same normalization as shrinkwrap mode).
- `fetchNpmDeps`/the plugin derivation inject the sidecar as `package-lock.json` in `postPatch` (the nixpkgs-documented path), so the plugin installs offline from `npmDepsHash`.
- Partial evidence entries (`omittedWorkspaceDependencies` non-empty) are refused with a distinct skip reason; none of the seven lockless plugins are partial.
- Provenance: pure CI checks sidecar hashes structurally; the pin workflow's validate step re-fetches the published asset (`OPENCLAW_RUNTIME_PLUGIN_VERIFY_EVIDENCE_ASSET=1`) and compares bytes. A local evidence override (`OPENCLAW_RUNTIME_PLUGIN_DEPENDENCY_EVIDENCE_ZIP`) is for maintainer pre-release validation only, requires `OPENCLAW_RUNTIME_PLUGIN_ALLOW_EVIDENCE_OVERRIDE=1`, and cannot pass pure CI.
- `update-pins.sh` registers new sidecars with `git add --intent-to-add` right after regeneration: the gateway build inside `apply` stages the acpx plugin, and git-based flake sources only see tracked files.

Releases without the report behave exactly as before (same skip reason, extended detail text). `shrinkwrap` and `bundled` paths are unchanged.

## Impact

Once an OpenClaw release ships the evidence report, all seven lockless catalog plugins become packageable again and the stable pin can advance. Until then nothing changes for users.

## Evidence

- Live Linux proof on a Crabbox AWS lease (Determinate Nix) with an evidence zip generated from the OpenClaw `v2026.9.1` tag using the upstream generator: `update-openclaw-runtime-plugin-locks.mjs` went from 82 supported / 13 skipped (acpx rejected) to 89 / 6 with all seven plugins in `package-lock` mode; sidecar SHA-256 equals the evidence `lockSha256`; `--check` clean; checker fails without the override allowance and passes with it; `checks.x86_64-linux.runtime-plugin-locks` passes (`--impure`) and correctly fails pure; all seven plugin derivations built offline; the acpx output holds every direct dependency at its pinned version and `acpx --version` prints 0.13.1 from the store.
- 75 `node --test` contract tests (all CI-listed files) pass; `bash -n`, workflow YAML parse, `git diff --check` clean. Codex autoreview scoped-clean at P0–P2 on the final head.
- Not covered here: the OpenClaw gateway wrapper lock for `openclaw@2026.9.1` (`nix/npm/openclaw`, generated by npm 10) is missing the direct dependency `p-limit@7.3.1`, so the gateway's offline `npm ci` fails with ENOTCACHED. That is an independent 2026.9.1 blocker and needs its own fix.

AI-assisted (Codex workers under maintainer direction), fully tested as described above.

Refs openclaw/openclaw#134190, openclaw/openclaw#114006.
