### PR TITLE
build: refresh pnpm and consolidate packaging notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ Older repository history is available in git.
 
 ## Unreleased
 
-**Highlights:** More reliable Home Manager activation and isolated, updated package-manager tooling. Changes below cover the package state since `v2026.7.1`.
+**Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and Home Manager activation handles paths and cleanup more reliably. Changes below cover the package state since `v2026.7.1`.
 
+- Materialize configured user and plugin skills as per-instance runtime copies, preserving all-agent discovery, extra load paths, and cleanup boundaries; thanks @vsumner (#118).
 - Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).
 - Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
 - Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
-- Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.25.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).
+- Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.26.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).
 - Restart the configured launchd labels and systemd user units with `openclaw-reload` instead of the old hardcoded labels.
 - Package upstream OpenClaw `2026.7.1-2`, retain runtime plugin version `2026.7.1` for correction releases, and repair the macOS `2026.7.1` app artifact hash; thanks @vincentkoc.
 - Preserve canonical scoped npm package encoding and fully escape generated CI table cells; thanks @vincentkoc (#114).

--- a/nix/packages/pnpm-11.nix
+++ b/nix/packages/pnpm-11.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
-  version = "11.25.0";
+  version = "11.26.0";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
-    hash = "sha256-M90HSPJ+eRbE8ci2lDRhmD40U7BrvaYxKmKAEwtIgeU=";
+    hash = "sha256-wzIgfnOPhLfM+V1fIfb98QsNxbEz8KNJg0om/RerrNg=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Refresh the private pnpm 11 tool to 11.26.0 and consolidate the complete Unreleased notes since v2026.7.1. pnpm 12 remains current at 12.3.4, and the existing Node.js 22 runtime stays in place.

**Land after #128.** The skill-copy changelog entry records that prerequisite; this independent branch intentionally contains no skill implementation changes.

Validation on `f445542d146ab38e67635b9a858993cb0e26d59e`:

- [CI passed on Linux and macOS](https://github.com/openclaw/nix-openclaw/actions/runs/34107445773), including the Nix pnpm runtime checks, package artifacts, module rendering, gateway smoke, platform activation, runtime plugins, and QMD opt-in.
- Downloaded the published pnpm 11.26.0 tarball and verified SHA-256 `wzIgfnOPhLfM+V1fIfb98QsNxbEz8KNJg0om/RerrNg=` against the Nix pin.
- Ran the repository wrapper and pnpm runtime scenarios with verified Node 22.23.2 on macOS: offline local-tarball installation, package execution, unchanged lockfile, and rejection of a mismatched frozen lockfile all passed. The entrypoint reports 11.26.0.
- All 75 JavaScript contract tests pass. Codex committed-branch review is scoped-clean through P2.

The upstream gateway update remains blocked: the public v2026.9.1 and v2026.9.2 dependency-evidence ZIPs lack the npm package-lock report needed for lockless catalog plugins. No gateway pins or mirrored release tags change here.
