### PR TITLE
fix: resolve Home Manager instance paths consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,8 @@ Use named instances when you need two local gateways. Keep the default package u
 
 Config activation supports paths containing spaces, including a custom
 `instances.<name>.configPath`. A leading `~/` is resolved against the configured
-Home Manager home directory before the config symlink is created.
+Home Manager home directory for activation, `home.file` destinations, the
+workspace pin, and launchd/systemd WorkingDirectory and environment paths.
 Systemd environment entries preserve spaces in the config and state paths.
 
 ```nix

--- a/nix/checks/openclaw-default-instance.nix
+++ b/nix/checks/openclaw-default-instance.nix
@@ -173,14 +173,70 @@ let
   homeRelativeConfigEval = moduleEval {
     instances.default.stateDir = "~/openclaw state";
   };
-  homeRelativeConfigCheck =
+  homeRelativeConfigCheckFor = eval:
     let
-      activation = homeRelativeConfigEval.config.home.activation.openclawConfigFiles.data;
+      activation = eval.config.home.activation.openclawConfigFiles.data;
+      homeFile = eval.config.home.file;
+      generated =
+        if builtins.hasAttr "openclaw state/openclaw.json" homeFile then
+          generatedConfig eval "openclaw state/openclaw.json"
+        else
+          { };
+      systemdService =
+        if pkgs.stdenv.hostPlatform.isLinux then
+          eval.config.systemd.user.services.openclaw-gateway.Service or { }
+        else
+          { };
+      launchdConfig =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          eval.config.launchd.agents."com.steipete.openclaw.gateway".config or { }
+        else
+          { };
     in
     if !(lib.hasInfix " '/tmp/openclaw state/openclaw.json'" activation) then
       throw "Config activation must resolve home-relative paths before shell escaping."
+    else if builtins.hasAttr "~/openclaw state/openclaw.json" homeFile then
+      throw "home.file still uses an unresolved ~/ config destination."
+    else if !(builtins.hasAttr "openclaw state/openclaw.json" homeFile) then
+      throw "home.file must materialize the resolved config path, not a literal ~/ destination."
+    else if (((generated.agents or { }).defaults or { }).workspace or null) != "/tmp/openclaw state/workspace" then
+      throw "Workspace pin must resolve home-relative workspaceDir."
+    else if pkgs.stdenv.hostPlatform.isLinux && ((systemdService.WorkingDirectory or "") != "/tmp/openclaw state") then
+      throw "Systemd WorkingDirectory must resolve home-relative stateDir."
+    else if
+      pkgs.stdenv.hostPlatform.isLinux
+      && !(lib.elem "\"OPENCLAW_STATE_DIR=/tmp/openclaw state\"" (systemdService.Environment or [ ]))
+    then
+      throw "Systemd OPENCLAW_STATE_DIR must resolve home-relative stateDir."
+    else if
+      pkgs.stdenv.hostPlatform.isLinux
+      && !(lib.elem "\"OPENCLAW_CONFIG_PATH=/tmp/openclaw state/openclaw.json\"" (
+        systemdService.Environment or [ ]
+      ))
+    then
+      throw "Systemd OPENCLAW_CONFIG_PATH must resolve home-relative configPath."
+    else if pkgs.stdenv.hostPlatform.isDarwin && ((launchdConfig.WorkingDirectory or "") != "/tmp/openclaw state") then
+      throw "launchd WorkingDirectory must resolve home-relative stateDir."
+    else if
+      pkgs.stdenv.hostPlatform.isDarwin
+      && (((launchdConfig.EnvironmentVariables or { }).OPENCLAW_STATE_DIR or null) != "/tmp/openclaw state")
+    then
+      throw "launchd OPENCLAW_STATE_DIR must resolve home-relative stateDir."
+    else if
+      pkgs.stdenv.hostPlatform.isDarwin
+      && (
+        ((launchdConfig.EnvironmentVariables or { }).OPENCLAW_CONFIG_PATH or null)
+        != "/tmp/openclaw state/openclaw.json"
+      )
+    then
+      throw "launchd OPENCLAW_CONFIG_PATH must resolve home-relative configPath."
     else
       "ok";
+
+  homeRelativeConfigCheck = homeRelativeConfigCheckFor homeRelativeConfigEval;
+  topLevelHomeRelativeConfigCheck = homeRelativeConfigCheckFor (moduleEval {
+    stateDir = "~/openclaw state";
+  });
 
   spacedConfigEval = moduleEval {
     instances.default.configPath = "/tmp/openclaw state/config 'file'.json";
@@ -1051,6 +1107,7 @@ let
     [
       defaultCheck
       homeRelativeConfigCheck
+      topLevelHomeRelativeConfigCheck
       spacedConfigEnvironmentCheck
       reloadDefaultCheck
       reloadNamedCheck

--- a/nix/checks/openclaw-hm-activation.nix
+++ b/nix/checks/openclaw-hm-activation.nix
@@ -68,7 +68,8 @@ pkgs.testers.nixosTest {
               installApp = false;
               launchd.enable = false;
               instances.default = {
-                configPath = "/home/alice/.openclaw/config with spaces and 'quotes'.json";
+                stateDir = "~/openclaw state";
+                configPath = "~/openclaw state/config with spaces and 'quotes'.json";
                 workspaceDir = "~/custom workspace";
                 gatewayPort = 18999;
                 config = {

--- a/nix/modules/home-manager/openclaw/config.nix
+++ b/nix/modules/home-manager/openclaw/config.nix
@@ -112,6 +112,9 @@ let
   mkInstanceConfig =
     name: inst:
     let
+      stateDir = openclawLib.resolvePath inst.stateDir;
+      workspaceDir = openclawLib.resolvePath inst.workspaceDir;
+      configPath = openclawLib.resolvePath inst.configPath;
       gatewayPackage =
         if inst.gatewayPath != null then
           pkgs.callPackage ../../../packages/openclaw-gateway.nix {
@@ -214,7 +217,7 @@ let
           lib.recursiveUpdate mergedConfig0 {
             agents = {
               defaults = {
-                workspace = inst.workspaceDir;
+                workspace = workspaceDir;
               };
             };
           }
@@ -251,7 +254,7 @@ let
         in
         lib.unique ([ "main" ] ++ configured);
       codexRuntimeProfiles = map (
-        agentId: "${inst.stateDir}/agents/${agentId}/agent/codex-home/home/.nix-profile"
+        agentId: "${stateDir}/agents/${agentId}/agent/codex-home/home/.nix-profile"
       ) agentIds;
       gatewayWrapper = pkgs.writeShellScriptBin "openclaw-gateway-${name}" ''
         set -euo pipefail
@@ -311,7 +314,7 @@ let
     {
       name = name;
       homeFile = {
-        name = openclawLib.toRelative inst.configPath;
+        name = openclawLib.toRelative configPath;
         value = {
           source = configFile;
           text = builtins.unsafeDiscardStringContext configJson;
@@ -319,13 +322,13 @@ let
         };
       };
       configFile = configFile;
-      configPath = inst.configPath;
+      configPath = configPath;
       codexRuntimeProfiles = codexRuntimeProfiles;
       runtimeProfile = runtimeProfile;
 
       dirs = [
-        inst.stateDir
-        inst.workspaceDir
+        stateDir
+        workspaceDir
         (builtins.dirOf inst.logPath)
       ];
 
@@ -342,13 +345,13 @@ let
             ];
             RunAtLoad = true;
             KeepAlive = true;
-            WorkingDirectory = inst.stateDir;
+            WorkingDirectory = stateDir;
             StandardOutPath = inst.logPath;
             StandardErrorPath = inst.logPath;
             EnvironmentVariables = {
               HOME = homeDir;
-              OPENCLAW_CONFIG_PATH = inst.configPath;
-              OPENCLAW_STATE_DIR = inst.stateDir;
+              OPENCLAW_CONFIG_PATH = configPath;
+              OPENCLAW_STATE_DIR = stateDir;
               OPENCLAW_IMAGE_BACKEND = "sips";
               OPENCLAW_NIX_MODE = "1";
             }
@@ -366,14 +369,14 @@ let
           };
           Service = {
             ExecStart = "${gatewayWrapper}/bin/openclaw-gateway-${name} gateway --port ${toString inst.gatewayPort}";
-            WorkingDirectory = inst.stateDir;
+            WorkingDirectory = stateDir;
             Restart = "always";
             RestartSec = "1s";
             # Systemd needs whole quoted items, not shell quote concatenation.
             Environment = map builtins.toJSON [
               "HOME=${homeDir}"
-              "OPENCLAW_CONFIG_PATH=${inst.configPath}"
-              "OPENCLAW_STATE_DIR=${inst.stateDir}"
+              "OPENCLAW_CONFIG_PATH=${configPath}"
+              "OPENCLAW_STATE_DIR=${stateDir}"
               "OPENCLAW_NIX_MODE=1"
             ]
             ++ lib.optional disablePersistedPluginRegistry "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY=1";

--- a/nix/tests/hm-activation-macos/home.nix
+++ b/nix/tests/hm-activation-macos/home.nix
@@ -31,7 +31,8 @@
     runtimePackages = [ pkgs.jq ];
     environment.OPENCLAW_TEST_SECRET = "/tmp/openclaw-secret";
     instances.default = {
-      configPath = "/tmp/hm-activation-home/.openclaw/config with spaces and 'quotes'.json";
+      stateDir = "~/openclaw state";
+      configPath = "~/openclaw state/config with spaces and 'quotes'.json";
       workspaceDir = "~/custom workspace";
       gatewayPort = 18999;
       logPath = "/tmp/hm-activation-home/.openclaw/openclaw-gateway.log";

--- a/nix/tests/hm-activation.py
+++ b/nix/tests/hm-activation.py
@@ -8,9 +8,13 @@ machine.wait_until_succeeds(
     "systemctl show -p SubState home-manager-alice.service | grep -Eq '^SubState=(dead|exited)$'"
 )
 
-config_path = shlex.quote("/home/alice/.openclaw/config with spaces and 'quotes'.json")
+state_dir = "/home/alice/openclaw state"
+config_path = shlex.quote(f"{state_dir}/config with spaces and 'quotes'.json")
 machine.wait_until_succeeds(f"test -f {config_path}")
 machine.succeed(f"test -L {config_path}")
+machine.succeed("test ! -e /home/alice/'~'")
+generated = json.loads(machine.succeed(f"cat {config_path}"))
+assert generated["agents"]["defaults"]["workspace"] == "/home/alice/custom workspace"
 workspace = "'/home/alice/custom workspace'"
 machine.wait_until_succeeds(f"test -f {workspace}/AGENTS.md")
 machine.succeed(f"test ! -L {workspace}/AGENTS.md")
@@ -21,7 +25,7 @@ machine.succeed(f"test -f {workspace}/LORE.md")
 machine.succeed(f"grep -q '\"skipBootstrap\":true' {config_path}")
 machine.succeed(f"grep -q 'BEGIN NIX-REPORT' {workspace}/TOOLS.md")
 machine.wait_until_succeeds(
-    "test -x /home/alice/.openclaw/agents/main/agent/codex-home/home/.nix-profile/bin/jq"
+    f"test -x {shlex.quote(state_dir)}/agents/main/agent/codex-home/home/.nix-profile/bin/jq"
 )
 
 skill_root = "/home/alice/.local/share/nix-openclaw/skills/default"
@@ -48,6 +52,13 @@ user_env = "XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/r
 machine.succeed(f"su - alice -c '{user_env} systemctl --user daemon-reload'")
 machine.succeed(f"su - alice -c '{user_env} systemctl --user start openclaw-gateway.service'")
 machine.wait_for_unit("openclaw-gateway.service", user="alice")
+pid = machine.succeed(
+    f"su - alice -c '{user_env} systemctl --user show openclaw-gateway.service -p MainPID --value'"
+).strip()
+assert machine.succeed(f"readlink /proc/{pid}/cwd").strip() == state_dir
+environment = machine.succeed(f"cat /proc/{pid}/environ").split("\0")
+assert f"OPENCLAW_STATE_DIR={state_dir}" in environment
+assert f"OPENCLAW_CONFIG_PATH={state_dir}/config with spaces and 'quotes'.json" in environment
 
 try:
     machine.wait_for_open_port(18999)

--- a/scripts/hm-activation-macos.sh
+++ b/scripts/hm-activation-macos.sh
@@ -41,13 +41,16 @@ fi
 test ! -e "$HOME/custom workspace"
 "$activation_package/activate"
 
-test -f "$HOME/.openclaw/config with spaces and 'quotes'.json"
-test -L "$HOME/.openclaw/config with spaces and 'quotes'.json"
+config_path="$HOME/openclaw state/config with spaces and 'quotes'.json"
+test -f "$config_path"
+test -L "$config_path"
+test ! -e "$HOME/~"
+grep -q '"workspace":"/tmp/hm-activation-home/custom workspace"' "$config_path"
 test -f "$HOME/custom workspace/LORE.md"
 test ! -L "$HOME/custom workspace/LORE.md"
 test -f "$plist"
-test -L "$HOME/.openclaw/agents/main/agent/codex-home/home/.nix-profile/bin"
-test -x "$HOME/.openclaw/agents/main/agent/codex-home/home/.nix-profile/bin/jq"
+test -L "$HOME/openclaw state/agents/main/agent/codex-home/home/.nix-profile/bin"
+test -x "$HOME/openclaw state/agents/main/agent/codex-home/home/.nix-profile/bin/jq"
 
 skill_root="$HOME/.local/share/nix-openclaw/skills/default"
 for skill in activation-skill copied-skill; do
@@ -58,6 +61,9 @@ test -z "$(find "$skill_root" -type f ! -links 1 -print)"
 test -z "$(find "$skill_root" -type f ! -user "$(id -un)" -print)"
 
 if command -v launchctl >/dev/null 2>&1; then
+  test "$(/usr/libexec/PlistBuddy -c 'Print :WorkingDirectory' "$plist")" = "$HOME/openclaw state"
+  test "$(/usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:OPENCLAW_STATE_DIR' "$plist")" = "$HOME/openclaw state"
+  test "$(/usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:OPENCLAW_CONFIG_PATH' "$plist")" = "$config_path"
   state_file="$home_dir/launchd-state.txt"
   running=false
   for _ in {1..20}; do
@@ -79,7 +85,7 @@ if command -v launchctl >/dev/null 2>&1; then
     openclaw_bin=${openclaw_bin%% gateway*}
   fi
   grep -q OPENCLAW_TEST_SECRET "$openclaw_bin"
-  OPENCLAW_CONFIG_PATH="$HOME/.openclaw/config with spaces and 'quotes'.json" \
+  OPENCLAW_CONFIG_PATH="$config_path" \
     "$openclaw_bin" skills list --json > "$home_dir/skills.json"
   grep -Eq '"name"[[:space:]]*:[[:space:]]*"activation-skill"' "$home_dir/skills.json"
   grep -Eq '"name"[[:space:]]*:[[:space:]]*"skill"' "$home_dir/skills.json"


### PR DESCRIPTION
The documented `stateDir = "~/.openclaw"` setting was expanded during activation but remained literal in Home Manager file destinations, workspace defaults, runtime profiles, and launchd/systemd settings. Those consumers could point at different directories or prevent the gateway from starting.

Resolve the three instance paths through the existing helper before rendering them. Explicit upstream workspace settings and absolute defaults keep their behavior. Based on @SebTardif's investigation and patch in #130, extended with top-level configuration coverage and Linux/macOS activation fixtures using home-relative state and config paths containing spaces and quotes.

Closes #130.

Validation on `6cec9ba92a8f0e69c39612bdf794fdf052f8ff39`: [full Linux and macOS CI passed](https://github.com/openclaw/nix-openclaw/actions/runs/34175176586), including real gateway startup, Linux process working directory/environment checks, and macOS launchd gateway health. New Nix regression assertions fail on main and pass with this implementation on both platforms. A real Home Manager base-to-head generation switch removes the obsolete config link while preserving workspace memory and legacy runtime data; the resolved runtime profile remains executable. That filesystem probe uses a placeholder application package, while CI exercises the real gateway.

All 80 JavaScript contract tests, flake owner validation, syntax checks, and independent branch review through P2 pass. Complete Unreleased notes are in #132, to land after this independent fix branch.
