### PR TITLE
build: refresh Nix dependencies and consolidate packaging notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Older repository history is available in git.
 - Package upstream OpenClaw `2026.7.1-2`, retain runtime plugin version `2026.7.1` for correction releases, and repair the macOS `2026.7.1` app artifact hash; thanks @vincentkoc.
 - Preserve canonical scoped npm package encoding and fully escape generated CI table cells; thanks @vincentkoc (#114).
 - Document declarative Gmail hook session keys and their allowed prefix to prevent rejected callbacks (#113).
+- Refresh Nixpkgs, Home Manager, the packaged OpenClaw tools, and the Linux QMD memory backend to 2.8.3, keeping bundled tool plugin sources aligned with the flake lock.
 - Refresh CI checkout to 7.0.1 and the Nix installer to 31.11.1, which fixes a Nix build crash.
 
 ## 2026-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ Older repository history is available in git.
 
 ## Unreleased
 
-**Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and Home Manager activation handles paths and cleanup more reliably. Changes below cover the package state since `v2026.7.1`.
+**Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and documented home-relative paths work consistently across Home Manager activation and gateway services. Changes below cover the package state since `v2026.7.1`.
 
-- Regenerate the gateway npm wrapper lock from scratch on every stable pin refresh and validate it offline before `npm ci`; updating the previous release's lock in place left OpenClaw 2026.9.x without its hoisted `p-limit@7` dependency and failed the Nix gateway build with ENOTCACHED (2026-09-07).
 - Materialize configured user and plugin skills as per-instance runtime copies, preserving all-agent discovery, extra load paths, and cleanup boundaries; thanks @vsumner (#118).
+- Resolve leading `~/` in instance state, workspace, and config paths consistently for managed files, runtime profiles, and launchd/systemd services, including paths containing spaces and quotes; thanks @SebTardif (#130).
 - Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).
+- Regenerate the gateway npm wrapper lock from scratch on every stable pin refresh and validate it offline before `npm ci`; updating the previous release's lock in place left OpenClaw 2026.9.x without its hoisted `p-limit@7` dependency and failed the Nix gateway build with ENOTCACHED (2026-09-07).
 - Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
 - Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
 - Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.26.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783963347,
-        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778060041,
-        "narHash": "sha256-tXWkN1VnwFG8XlRqW/e7VwbKnUfyU9tB7YDm9QHJXTY=",
+        "lastModified": 1788766984,
+        "narHash": "sha256-FF75z2jVZJjymkLtt7e7rKBLQZtC1LBEoM8qDhQPLQ8=",
         "owner": "openclaw",
         "repo": "nix-openclaw-tools",
-        "rev": "4c1cee3c7eaf68f9de0f756be1484534f5bb5f34",
+        "rev": "25fcec492e22996af9ee87106338a448bc6893a2",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {
@@ -98,16 +98,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775429264,
-        "narHash": "sha256-bqIVaNRTa8H5vrw3RwsD7QdtTa0xNvRuEVzlzE1hIBQ=",
+        "lastModified": 1786919312,
+        "narHash": "sha256-/7Z94r/9rXqzKlz/YkB6/nToSCPamV4Dnxm8EhelTDo=",
         "owner": "tobi",
         "repo": "qmd",
-        "rev": "65cd1b3fd02891d1ee0eefa751620918664fa321",
+        "rev": "facd35e01359e59d938bc9418e93fb9318addee3",
         "type": "github"
       },
       "original": {
         "owner": "tobi",
-        "ref": "v2.1.0",
+        "ref": "v2.8.3",
         "repo": "qmd",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     nix-openclaw-tools.url = "github:openclaw/nix-openclaw-tools";
-    qmd.url = "github:tobi/qmd/v2.1.0";
+    qmd.url = "github:tobi/qmd/v2.8.3";
     qmd.inputs.flake-utils.follows = "flake-utils";
     qmd.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/nix/modules/home-manager/openclaw/lib.nix
+++ b/nix/modules/home-manager/openclaw/lib.nix
@@ -28,8 +28,8 @@ let
 
   bundledPluginSources =
     let
-      openclawToolsRev = "4c1cee3c7eaf68f9de0f756be1484534f5bb5f34";
-      openclawToolsNarHash = "sha256-tXWkN1VnwFG8XlRqW/e7VwbKnUfyU9tB7YDm9QHJXTY=";
+      openclawToolsRev = "25fcec492e22996af9ee87106338a448bc6893a2";
+      openclawToolsNarHash = "sha256-FF75z2jVZJjymkLtt7e7rKBLQZtC1LBEoM8qDhQPLQ8=";
       openclawTools =
         tool:
         "github:openclaw/nix-openclaw-tools?dir=tools/${tool}&rev=${openclawToolsRev}&narHash=${openclawToolsNarHash}";

--- a/nix/scripts/check-openclaw-qmd-runtime.sh
+++ b/nix/scripts/check-openclaw-qmd-runtime.sh
@@ -36,6 +36,23 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 mkdir -p "$tmp_dir/home" "$tmp_dir/state" "$tmp_dir/config" "$tmp_dir/cache" "$tmp_dir/data" "$tmp_dir/logs"
+mkdir -p "$tmp_dir/notes"
+run_qmd() {
+  env HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/config" \
+    XDG_CACHE_HOME="$tmp_dir/cache" XDG_DATA_HOME="$tmp_dir/data" \
+    NO_COLOR=1 "$qmd_bin" "$@"
+}
+printf '# Packaging probe\nInitial document.\n' > "$tmp_dir/notes/proof.md"
+run_qmd collection add "$tmp_dir/notes" --name nix-smoke >/dev/null
+printf '# Packaging probe\nNixqmdproof verifies updated document retrieval.\n' > "$tmp_dir/notes/proof.md"
+run_qmd update >/dev/null
+run_qmd search nixqmdproof -c nix-smoke --json > "$tmp_dir/search.json"
+if ! grep -Fq 'qmd://nix-smoke/proof.md' "$tmp_dir/search.json"; then
+  echo "QMD did not retrieve the updated synthetic document" >&2
+  cat "$tmp_dir/search.json" >&2
+  exit 1
+fi
+
 cat > "$tmp_dir/state/openclaw.json" <<'JSON'
 {
   "gateway": {


### PR DESCRIPTION
Refresh the stale Nix package inputs while keeping the source/app release pins on the latest package state that passes the reproducibility contract:

- Nixpkgs: July 11 to September 7, 2026.
- Home Manager: July 13 to September 5, 2026.
- nix-openclaw-tools: May 6 to September 7, 2026, including matching fixed revision/hash values for bundled tool plugin sources.
- Optional Linux QMD backend: 2.1.0 to 2.8.3. The Darwin backend continues to use the tools input.

Consolidate the complete Unreleased notes since `v2026.7.1`, placing skill discovery and Home Manager path fixes first and crediting @SebTardif for #130. Land this PR after #131; both are independently based on main and their files do not overlap.

Validation on `1d57953142fc79b81c790744426034f319cdc3e3`: [full Linux and macOS CI passed](https://github.com/openclaw/nix-openclaw/actions/runs/34176733031), including real gateway activation and health, runtime plugin hosting, private pnpm installs, and QMD collection creation, document update, indexing, and keyword retrieval. The QMD smoke runs the packaged binary in isolated HOME/XDG directories without downloading models. Nix 2.34.8 evaluation, flake owner validation, and final independent branch review through P2 also pass. An earlier macOS attempt hit a transient Nix cache HTTP 416; the final commit passed the complete suite.

No independent version bump or tag is proposed: this repository mirrors upstream OpenClaw versions. Gateway `2026.7.1-2` and app `2026.7.1` still differ. Promotion to `2026.9.2` remains blocked because the previously supported `acpx` runtime plugin lacks reproducible npm dependency evidence. Private pnpm 11.26.0/12.3.4 and the GitHub Action pins are current.
