### PR TITLE
fix(ci): admit maintainer and bind test shell to locked input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -44,7 +44,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -97,7 +97,7 @@ jobs:
       ${{
         github.repository == 'openclaw/nix-openclaw' &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","github-actions[bot]"]'), github.actor)
+        contains(fromJSON('["Asleep123","asleep123","badlogic","bjesuiter","christianklotz","cpojer","Evizero","evizero","gumadeiras","joshp123","mbelinky","mukhtharcm","obviyus","onutc","pasogott","sebslight","sergiopesch","shakkernerd","steipete","Takhoffman","takhoffman","thewilloftheshadow","tyler6204","vignesh07","vincentkoc","github-actions[bot]"]'), github.actor)
       }}
     runs-on: macos-14
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Test JavaScript contracts
         run: |
-          nix shell nixpkgs#nodejs_22 --command node --test \
+          nix shell --option flake-registry '' --inputs-from . nixpkgs#nodejs_22 --command node --test \
             scripts/select-openclaw-release.test.mjs \
             maintainers/scripts/markdown-table.test.mjs \
             nix/scripts/openclaw-runtime-plugin-version.test.mjs \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Older repository history is available in git.
 **Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and documented home-relative paths work consistently across Home Manager activation and gateway services. Changes below cover the package state since `v2026.7.1`.
 
 - Admit @vincentkoc to the existing maintainer-only CI actor lists for provenance, Linux, and macOS validation (2026-09-09).
+- Run Linux JavaScript contract tests with Node.js 22 from the repository's locked Nixpkgs input and disable the global flake registry for that command, avoiding registry fetch failures (2026-09-09).
 - Materialize configured user and plugin skills as per-instance runtime copies, preserving all-agent discovery, extra load paths, and cleanup boundaries; thanks @vsumner (#118).
 - Resolve leading `~/` in instance state, workspace, and config paths consistently for managed files, runtime profiles, and launchd/systemd services, including paths containing spaces and quotes; thanks @SebTardif (#130).
 - Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Older repository history is available in git.
 
 **Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and documented home-relative paths work consistently across Home Manager activation and gateway services. Changes below cover the package state since `v2026.7.1`.
 
+- Admit @vincentkoc to the existing maintainer-only CI actor lists for provenance, Linux, and macOS validation (2026-09-09).
 - Materialize configured user and plugin skills as per-instance runtime copies, preserving all-agent discovery, extra load paths, and cleanup boundaries; thanks @vsumner (#118).
 - Resolve leading `~/` in instance state, workspace, and config paths consistently for managed files, runtime profiles, and launchd/systemd services, including paths containing spaces and quotes; thanks @SebTardif (#130).
 - Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).


### PR DESCRIPTION
## Summary

- Add `vincentkoc` immediately before the existing bot entry in all three CI actor lists.
- Resolve the Linux JavaScript test shell from the repository's locked Nixpkgs input and disable the global flake registry for that command.
- Keep Node.js 22, all nine test files, and every other workflow field unchanged. Include a dated operational changelog note in each of the two scoped commits.

## Root Causes

The three validation jobs independently check static actor lists. Adding an actor to only the provenance job would still leave Linux and macOS validation skipped.

The existing Linux test shell can fail before JavaScript tests while fetching the global flake registry. The observed main failure is [CI run 34177551535](https://github.com/openclaw/nix-openclaw/actions/runs/34177551535/job/101909968226).

In Nix 2.35.2, [`--inputs-from` binds locked inputs](https://github.com/NixOS/nix/blob/2.35.2/src/libcmd/installables.cc#L158-L182), but [registry lookup still constructs the global registry](https://github.com/NixOS/nix/blob/2.35.2/src/libfetchers/registry.cc#L129-L178). The approved command also sets the existing `flake-registry` option to an empty value for this invocation:

```sh
nix shell --option flake-registry '' --inputs-from . nixpkgs#nodejs_22 --command node --test ...
```

The actual workflow retains the complete existing argument list. No pins, locks, persistent settings, public options, permissions, fork policy, runners, timeouts, concurrency, or publisher behavior change.

## Verification

- [CI run 34285931123](https://github.com/openclaw/nix-openclaw/actions/runs/34285931123), attempt 1: PASS, fresh `pull_request` event, actor `vincentkoc`.
- Reviewed head: `e4ab77c093b0d31c80976df93369c3f5e4ee98c9`.
- Actual checkout merge: `f678653fa27924253a4620a18644ba58cbb87152`, confirmed in closed provenance, Linux, and macOS job logs.
- Merge parents: base `5cbb2f1bdaf89575076cf95e9cee59c851c967fe`, head `e4ab77c093b0d31c80976df93369c3f5e4ee98c9`.
- Merge tree equals reviewed head tree: `831949464669d55833d1f9d68f3850ec588b605a`.

| Surface | Evidence |
| --- | --- |
| Provenance | [PASS](https://github.com/openclaw/nix-openclaw/actions/runs/34285931123/job/102261401716); actual admission and flake-owner check succeeded. |
| Linux | [PASS, 5m37s](https://github.com/openclaw/nix-openclaw/actions/runs/34285931123/job/102261427356). Maintainer inspected the closed log: Nix 2.35.2, corrected command, 80 tests passed, 0 failed, 0 skipped, and all seven native proof groups passed. |
| macOS | [PASS, 9m29s](https://github.com/openclaw/nix-openclaw/actions/runs/34285931123/job/102261427466), including supported-surface build and launchd activation. Maintainer verified the same checkout merge in the closed log. |
| PR publisher | [SKIPPED](https://github.com/openclaw/nix-openclaw/actions/runs/34285931123/job/102264005719), as required by the unchanged main-only publishing guard. |

Local checks passed: YAML parse, actionlint, provenance, shell syntax/argument identity, exact three-array and remaining-workflow invariants, whitespace, signatures, and privacy. The 72 supplemental admission-model assertions are not GitHub expression-engine execution. Node.js 22 and all nine existing test files remain unchanged. Workflow delta +4/-4; changelog +2; application/test LOC zero.

Independent actual-diff review passed with no findings. The maintainer personally read the complete final [ClawSweeper review](https://github.com/openclaw/nix-openclaw/pull/136#issuecomment-5592757051), updated `2026-09-08T22:30:35Z`, for the exact head above: no findings, security items, or before-merge items; no Rank-up moves listed. ClawSweeper gate addressed by maintainer review; no re-review needed.

## Landing Checks

Maintainer-authorized normal squash only, subject to unchanged head/base and the final live review, check, policy, and content checks. Pins and publisher files remain byte-identical to the bound base.

The non-mutating publisher `check`, run from the exact candidate with `GITHUB_OUTPUT` and `GITHUB_STEP_SUMMARY` unset, returned `eligible=false`, `skip_reason=source-app-version-mismatch`, source `2026.7.1-2`, app `2026.7.1`. Repeat immediately before merge; drift or eligibility stops landing. Resulting main CI and its publisher no-op remain for post-merge observation. No release, deployment, or tag promotion is authorized.
