### PR TITLE
fix: include removed plugins in stable pin promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           nix shell --option flake-registry '' --inputs-from . nixpkgs#nodejs_22 --command node --test \
             scripts/select-openclaw-release.test.mjs \
+            scripts/pin-promotion.test.mjs \
             maintainers/scripts/markdown-table.test.mjs \
             nix/scripts/openclaw-runtime-plugin-version.test.mjs \
             nix/scripts/openclaw-runtime-plugin-package-locks.test.mjs \

--- a/.github/workflows/pin-stable-openclaw-version.yml
+++ b/.github/workflows/pin-stable-openclaw-version.yml
@@ -98,9 +98,9 @@ jobs:
           while IFS= read -r file; do
             pin_files+=("$file")
           done < <(scripts/update-pins.sh files)
-          git add --intent-to-add -- "${pin_files[@]}"
+          git add -- "${pin_files[@]}"
           digest="$(
-            git diff --binary -- "${pin_files[@]}" \
+            git diff --cached --binary -- "${pin_files[@]}" \
               | shasum -a 256 \
               | awk '{ print $1 }'
           )"
@@ -190,9 +190,9 @@ jobs:
           while IFS= read -r file; do
             pin_files+=("$file")
           done < <(scripts/update-pins.sh files)
-          git add --intent-to-add -- "${pin_files[@]}"
+          git add -- "${pin_files[@]}"
           digest="$(
-            git diff --binary -- "${pin_files[@]}" \
+            git diff --cached --binary -- "${pin_files[@]}" \
               | shasum -a 256 \
               | awk '{ print $1 }'
           )"
@@ -293,7 +293,6 @@ jobs:
       - verify-materialization
     if: >-
       ${{
-        github.ref == 'refs/heads/main' &&
         needs.select.outputs.has_update == 'true'
       }}
     runs-on: ubuntu-latest
@@ -314,6 +313,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATED_MATERIALIZATION_DIGEST: ${{ needs.verify-materialization.outputs.materialization_digest }}
+          PROMOTE_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
           git config user.name "openclaw-ci"
@@ -329,15 +329,15 @@ jobs:
           while IFS= read -r file; do
             pin_files+=("$file")
           done < <(scripts/update-pins.sh files)
-          git add --intent-to-add -- "${pin_files[@]}"
+          git add -- "${pin_files[@]}"
 
-          if git diff --quiet -- "${pin_files[@]}"; then
+          if git diff --cached --quiet -- "${pin_files[@]}"; then
             echo "No pin changes detected."
             exit 0
           fi
 
           promote_digest="$(
-            git diff --binary -- "${pin_files[@]}" \
+            git diff --cached --binary -- "${pin_files[@]}" \
               | shasum -a 256 \
               | awk '{ print $1 }'
           )"
@@ -348,10 +348,8 @@ jobs:
             exit 1
           fi
 
-          git add "${pin_files[@]}"
-
           git commit -F - <<EOF
-          🤖 codex: mirror OpenClaw stable source ${{ needs.select.outputs.source_tag }}
+          chore: mirror OpenClaw stable source ${{ needs.select.outputs.source_tag }}
 
           What:
           - update nix-openclaw to the latest stable OpenClaw source release
@@ -366,6 +364,11 @@ jobs:
           - nix build --accept-flake-config --option max-jobs 2 .#checks.aarch64-darwin.package-artifacts .#checks.aarch64-darwin.module-render .#checks.aarch64-darwin.runtime-smoke .#checks.aarch64-darwin.platform-activation .#checks.aarch64-darwin.runtime-plugin-packages .#checks.aarch64-darwin.runtime-plugin-host .#checks.aarch64-darwin.qmd-opt-in
           - scripts/hm-activation-macos.sh
           EOF
+
+          if [[ "$PROMOTE_REF" != "refs/heads/main" ]]; then
+            echo "Validated promotion commit on $PROMOTE_REF; skipping main push."
+            exit 0
+          fi
 
           git fetch origin main
           git rebase origin/main

--- a/maintainers/automation.md
+++ b/maintainers/automation.md
@@ -25,6 +25,11 @@ If both tracks are current and stable pin automation/CI are healthy, stop with a
 
 ## Repair Loop
 
+To prove stable-pin repairs before landing, dispatch `Pin Stable OpenClaw
+Version` on a maintainer branch. It runs the Linux/macOS package gates and
+verifies a local promotion commit, including added and removed generated files.
+Only `main` pushes the resulting pin update and dispatches publication CI.
+
 If the desired state is not true, keep working until it is true or until the exact blocker is proven.
 
 Diagnose across:

--- a/scripts/pin-promotion.test.mjs
+++ b/scripts/pin-promotion.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/pin-stable-openclaw-version.yml", import.meta.url), "utf8");
+// Execute the workflow's actual shell bodies so a staging regression cannot
+// hide behind a separate test implementation of promotion.
+function stepScripts(name) {
+  return [...workflow.matchAll(new RegExp(`      - name: ${name}\\n[\\s\\S]*?        run: \\|\\n((?:          .*\\n|\\n)+)`, "g"))]
+    .map((match) => match[1].replace(/^          /gm, ""));
+}
+const digestScripts = stepScripts("Record materialized diff digest");
+const [promotionScript] = stepScripts("Promote selected release");
+assert.equal(digestScripts.length, 2);
+assert.ok(promotionScript);
+
+function fixture(t, { deletionOnly = false, removePlugin = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "pin-promotion-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "Pin test", GIT_AUTHOR_EMAIL: "pin@example.invalid",
+    GIT_COMMITTER_NAME: "Pin test", GIT_COMMITTER_EMAIL: "pin@example.invalid",
+    GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null",
+    GITHUB_ACTIONS: "true", GITHUB_OUTPUT: join(root, "output"),
+    PROMOTE_REF: "refs/heads/test-promotion",
+  };
+  const git = (...args) => execFileSync("git", args, { cwd: root, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  const write = (path, text) => {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), text);
+  };
+  git("init", "--quiet", "--initial-branch=main");
+  write("nix/sources/openclaw-source.nix", "old pin\n");
+  write("nix/generated/openclaw-runtime-plugins/qqbot.nix", "retired plugin\n");
+  write("README.md", "unrelated\n");
+  // Only materialization is stubbed: these tests exercise real Git staging,
+  // hashing, commit creation, and the branch's no-publication boundary.
+  write("scripts/update-pins.sh", `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == apply ]]; then exit 0; fi
+printf '%s\\n' nix/sources/openclaw-source.nix
+{
+  git ls-files -- nix/generated/openclaw-runtime-plugins
+  find nix/generated/openclaw-runtime-plugins -type f
+} | sort -u
+`);
+  execFileSync("chmod", ["+x", join(root, "scripts/update-pins.sh")]);
+  git("add", ".");
+  git("commit", "--quiet", "-m", "fixture");
+  const baseline = git("rev-parse", "HEAD");
+  if (removePlugin) rmSync(join(root, "nix/generated/openclaw-runtime-plugins/qqbot.nix"));
+  if (!deletionOnly) {
+    write("nix/sources/openclaw-source.nix", "new pin\n");
+    write("nix/generated/openclaw-runtime-plugins/new-plugin.nix", "new plugin\n");
+  }
+  write("README.md", "unrelated dirty edit\n");
+  const shell = (script, extraEnv = {}) => spawnSync("bash", ["-e", "-c", script.replace(/\$\{\{[^}]+\}\}/g, "fixture")], {
+    cwd: root, env: { ...env, ...extraEnv }, encoding: "utf8",
+  });
+  return { root, git, shell, baseline };
+}
+function checked(result) {
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  return result.stdout;
+}
+function digest(f, script) {
+  checked(f.shell(script));
+  return readFileSync(join(f.root, "output"), "utf8").trim().split("=")[1];
+}
+
+for (const deletionOnly of [false, true]) {
+  test(`promotion includes removed plugins${deletionOnly ? " in a deletion-only update" : ", additions, and modified pins"}`, (t) => {
+    const validators = digestScripts.map((script) => {
+      const f = fixture(t, { deletionOnly });
+      return digest(f, script);
+    });
+    assert.equal(validators[0], validators[1]);
+    assert.notEqual(validators[0], createHash("sha256").update("").digest("hex"));
+    const f = fixture(t, { deletionOnly });
+    const output = checked(f.shell(promotionScript, { VALIDATED_MATERIALIZATION_DIGEST: validators[0] }));
+    assert.match(output, /Validated promotion commit.*skipping main push/);
+    assert.notEqual(f.git("rev-parse", "HEAD"), f.baseline);
+    const changes = f.git("diff-tree", "--no-commit-id", "--name-status", "-r", "HEAD");
+    assert.match(changes, /D\s+nix\/generated\/openclaw-runtime-plugins\/qqbot.nix/);
+    if (!deletionOnly) {
+      assert.match(changes, /A\s+nix\/generated\/openclaw-runtime-plugins\/new-plugin.nix/);
+      assert.match(changes, /M\s+nix\/sources\/openclaw-source.nix/);
+    }
+    assert.doesNotMatch(changes, /README/);
+    assert.equal(f.git("status", "--porcelain", "--untracked-files=no"), "M README.md");
+  });
+}
+
+test("a different removed-plugin set fails before committing", (t) => {
+  const validator = fixture(t, { removePlugin: false });
+  const expected = digest(validator, digestScripts[0]);
+  const promoter = fixture(t);
+  const result = promoter.shell(promotionScript, { VALIDATED_MATERIALIZATION_DIGEST: expected });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /different release diff/);
+  assert.equal(promoter.git("rev-parse", "HEAD"), promoter.baseline);
+});
+
+test("unchanged pins do not create a promotion commit", (t) => {
+  const f = fixture(t, { deletionOnly: true, removePlugin: false });
+  assert.match(checked(f.shell(promotionScript)), /No pin changes detected/);
+  assert.equal(f.git("rev-parse", "HEAD"), f.baseline);
+});


### PR DESCRIPTION
Stable pin promotion fails after both platforms validate OpenClaw 2026.9.4: `git add --intent-to-add` stages the removed `qqbot.nix`, so the later staging command rejects its now-missing path. The intervening unstaged diff also omits deleted files from the cross-platform digest.

Stage the pin update once and hash the staged diff in validation and promotion. This includes additions, modifications, and removals, supports deletion-only updates, and commits exactly the validated state. Maintainer branch dispatches now exercise the complete promotion commit locally; only main pushes pins and starts publication CI.

Validation: 197 JavaScript contract tests, seven profile-isolation tests, actionlint, shell syntax, and flake-owner checks pass locally. Three regression cases fail against the previous workflow, including the production pathspec error. Independent Codex review is clean through P2. Hosted package and branch-promotion proof is complete; see the exact-head evidence below.

Related: #142. Keep the issue open until main actually receives the validated pin update. The changelog entry is carried in the separate final maintenance-notes PR to avoid conflicts.

## Verified behavior

Verified head `bcd4ff12784e440ac247b6b28f9941e36dd62a2b`.

[The full stable-pin workflow passed](https://github.com/openclaw/nix-openclaw/actions/runs/34662171812): it selected OpenClaw 2026.9.4, materialized and validated the complete Linux and macOS package surfaces, ran activation, matched both staged materialization digests, and successfully created the promotion commit. The promotion log explicitly records deletion of `nix/generated/openclaw-runtime-plugins/qqbot.nix` and ends with:

```text
Validated promotion commit on refs/heads/fix/stable-pin-deletions-20260911; skipping main push.
```

This exercises the exact previously failing path with real release materialization and Git commit creation. No pins were pushed to main and no release was published by the branch run.

[Normal repository CI also passed](https://github.com/openclaw/nix-openclaw/actions/runs/34662172915) on the same head, including Linux/macOS gateway startup and health, runtime plugins, private pnpm binaries, and real Home Manager activation. CodeQL passed.

Local proof: `node --test scripts/pin-promotion.test.mjs` passes all four cases; three fail against the previous workflow, including the production missing-qqbot pathspec error. The complete JavaScript suite passes 197 tests; seven Python profile-isolation tests, actionlint, shell syntax, and flake-owner validation also pass. Local and committed-branch Codex autoreviews are clean through P2.

#142 stays open until the repaired workflow lands and actually promotes the new pins on main. The changelog entry is in #144, which should land after this PR.
