### PR TITLE
build: refresh Nix dependencies and packaging notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@ Older repository history is available in git.
 
 ## Unreleased
 
-**Highlights:** Nix-managed skills remain discoverable with OpenClaw’s hardlink checks, and documented home-relative paths work consistently across Home Manager activation and gateway services. Changes below cover the package state since `v2026.7.1`.
+**Highlights:** Restore automatic stable updates after runtime plugin removals, preserve Nix-managed skill discovery, and make Home Manager paths and activation consistent. Packaging compatibility for newer OpenClaw releases is ready for pin validation; changes below cover the package state since `v2026.7.1`.
 
-- Admit @vincentkoc to the existing maintainer-only CI actor lists for provenance, Linux, and macOS validation (2026-09-09).
-- Add an opt-in, non-main installed-baseline qualification for the unmodified `v2026.7.1` Nix recipe, using a disposable Linux VM and isolated macOS Home Manager profile. Build or startup failures block qualification without substituting packages; installed-generation upgrades remain unproven (2026-09-09).
-- Clarify that Home Manager generations restore package/configuration selections, not OpenClaw's mutable state or database schema; remove unconditional instant-rollback claims (2026-09-09).
-- Run Linux JavaScript contract tests with Node.js 22 from the repository's locked Nixpkgs input and disable the global flake registry for that command, avoiding registry fetch failures (2026-09-09).
+- Restore stable pin promotion when an upstream release removes runtime plugins: hash and commit the complete staged update, including deletions, and allow branch validation to prove promotion without publishing; thanks @bastislack (#142).
 - Materialize configured user and plugin skills as per-instance runtime copies, preserving all-agent discovery, extra load paths, and cleanup boundaries; thanks @vsumner (#118).
 - Resolve leading `~/` in instance state, workspace, and config paths consistently for managed files, runtime profiles, and launchd/systemd services, including paths containing spaces and quotes; thanks @SebTardif (#130).
-- Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).
+- Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
+- Make QMD backend integration legacy-only according to the generated OpenClaw schema. Before upgrading to a retired schema such as 2026.9.3, carry custom indexed paths and session-indexing settings into Nix source before removing `memory.backend`, `memory.qmd`, and `memory.search.qmd`; no automatic migration is performed. Preserve legacy opt-in, standalone QMD CLI packaging, and explicit model prewarming, with checks for both schema contracts (2026-09-09).
+- Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
+- Clarify that Home Manager generations restore package/configuration selections, not OpenClaw's mutable state or database schema; remove unconditional instant-rollback claims (2026-09-09).
+- Restart the configured launchd labels and systemd user units with `openclaw-reload` instead of the old hardcoded labels.
 - Regenerate the gateway npm wrapper lock from scratch on every stable pin refresh and validate it offline before `npm ci`; updating the previous release's lock in place left OpenClaw 2026.9.x without its hoisted `p-limit@7` dependency and failed the Nix gateway build with ENOTCACHED (2026-09-07).
 - Use the locked Node.js 24 runtime for OpenClaw builds, launchers, plugin materialization, private pnpm integrations, and bundled tools; Node.js 22 cannot install or run OpenClaw 2026.9.3 (2026-09-08).
 - Recognize the root `.js` and `.mjs` packaging contracts in OpenClaw 2026.7.1-2 and 2026.9.3, reusing upstream's hardlink predicate for Nix store ownership and retaining existing candidate-install guard limitations; source overrides and native validation remain separate (2026-09-08).
@@ -28,16 +29,16 @@ Older repository history is available in git.
 - Follow the pinned agent roster schema in Home Manager and its multi-agent checks. Keyed rosters use validated, lowercase profile IDs without an extra main agent; missing or empty non-explicit rosters emit `agents.entries.main = {}` even with workspace pinning disabled, without adding a workspace pin. Nonempty rosters, explicit ownership, and old-schema output stay unchanged (2026-09-08).
 - Match OpenClaw 2026.9.3 canonical keyed agent IDs for runtime profiles and collision checks, stripping trailing hyphens only from underscore-prefixed IDs while preserving authored rosters (2026-09-09).
 - Restore macOS app-default activation for the implicit Home Manager instance by supplying its existing `nixMode = true` default (2026-09-09).
-- Make QMD backend integration legacy-only according to the generated OpenClaw schema. Before upgrading to a retired schema such as 2026.9.3, carry custom indexed paths and session-indexing settings into Nix source before removing `memory.backend`, `memory.qmd`, and `memory.search.qmd`; no automatic migration is performed. Preserve legacy opt-in, standalone QMD CLI packaging, and explicit model prewarming, with checks for both schema contracts (2026-09-09).
-- Fix Home Manager config symlink activation and systemd environment quoting for paths containing spaces, while preserving home-relative `~/` symlink destinations; thanks @SebTardif (#122).
-- Constrain workspace cleanup and replacement to configured roots, preserve stale paths from removed or moved instances with a warning, avoid changing symlink targets or hardlinked file permissions, and create home-relative workspace paths containing spaces correctly; thanks @SebTardif (#119, #120).
-- Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.26.0 and 12.3.4, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).
-- Restart the configured launchd labels and systemd user units with `openclaw-reload` instead of the old hardcoded labels.
-- Package upstream OpenClaw `2026.7.1-2`, retain runtime plugin version `2026.7.1` for correction releases, and repair the macOS `2026.7.1` app artifact hash; thanks @vincentkoc.
+- Support packaging OpenClaw 2026.8.1+ lockless runtime plugins once upstream ships npm package-lock release evidence, with dependencies bound to the pinned release SHA (2026-09-06).
+- Keep OpenClaw's private pnpm tools out of the consumer Nixpkgs overlay, support pnpm 12 releases, update the private runtimes to pnpm 11.26.0 and 12.4.1, and fix the pnpm 12 Linux executable's loader and runtime libraries; thanks @jerome-benoit (#116, #117, #121).
 - Preserve canonical scoped npm package encoding and fully escape generated CI table cells; thanks @vincentkoc (#114).
 - Document declarative Gmail hook session keys and their allowed prefix to prevent rejected callbacks (#113).
 - Refresh Nixpkgs, Home Manager, the packaged OpenClaw tools, and the Linux QMD memory backend to 2.8.3, keeping bundled tool plugin sources aligned with the flake lock.
 - Refresh CI checkout to 7.0.1 and the Nix installer to 31.11.1, which fixes a Nix build crash.
+- Admit @vincentkoc to the existing maintainer-only CI actor lists for provenance, Linux, and macOS validation (2026-09-09).
+- Add an opt-in, non-main installed-baseline qualification for the unmodified `v2026.7.1` Nix recipe, using a disposable Linux VM and isolated macOS Home Manager profile. Build or startup failures block qualification without substituting packages; installed-generation upgrades remain unproven (2026-09-09).
+- Run Linux JavaScript contract tests with Node.js 22 from the repository's locked Nixpkgs input and disable the global flake registry for that command, avoiding registry fetch failures (2026-09-09).
+- Package upstream OpenClaw `2026.7.1-2`, retain runtime plugin version `2026.7.1` for correction releases, and repair the macOS `2026.7.1` app artifact hash; thanks @vincentkoc.
 
 ## 2026-09-04
 

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788651960,
-        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
+        "lastModified": 1789150619,
+        "narHash": "sha256-Vsgv5atXkGWOOdLOL8oQLnZSGt1h140synPfFdwbyjU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
+        "rev": "e4345d5ae8aa1def34378d2a60ac5e6e4c8fd7c1",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1788766984,
-        "narHash": "sha256-FF75z2jVZJjymkLtt7e7rKBLQZtC1LBEoM8qDhQPLQ8=",
+        "lastModified": 1789172097,
+        "narHash": "sha256-7see6mPJxBpPHilgFGOTZS3bAh2HrIP5ZVtaUdrNDUI=",
         "owner": "openclaw",
         "repo": "nix-openclaw-tools",
-        "rev": "25fcec492e22996af9ee87106338a448bc6893a2",
+        "rev": "c40fa16f6bef6bef2d89f0cdd3daf142364a4060",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1788834054,
+        "narHash": "sha256-9dzTcXMtlknZyT47Vv1PnpGgN7UYA8WxxqyxsKdvYbo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "e9b9cbecbf6c25ca26c150d78570e6332694a129",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788752844,
-        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {

--- a/nix/modules/home-manager/openclaw/lib.nix
+++ b/nix/modules/home-manager/openclaw/lib.nix
@@ -59,8 +59,8 @@ let
 
   bundledPluginSources =
     let
-      openclawToolsRev = "25fcec492e22996af9ee87106338a448bc6893a2";
-      openclawToolsNarHash = "sha256-FF75z2jVZJjymkLtt7e7rKBLQZtC1LBEoM8qDhQPLQ8=";
+      openclawToolsRev = "c40fa16f6bef6bef2d89f0cdd3daf142364a4060";
+      openclawToolsNarHash = "sha256-7see6mPJxBpPHilgFGOTZS3bAh2HrIP5ZVtaUdrNDUI=";
       openclawTools =
         tool:
         "github:openclaw/nix-openclaw-tools?dir=tools/${tool}&rev=${openclawToolsRev}&narHash=${openclawToolsNarHash}";

--- a/nix/packages/pnpm-12.nix
+++ b/nix/packages/pnpm-12.nix
@@ -12,11 +12,11 @@ let
     {
       aarch64-darwin = {
         package = "exe.darwin-arm64";
-        hash = "sha256-9UrTZ9ikLa+dhIMOS9akXAlX4OMoekXaCMOguNBOx/c=";
+        hash = "sha256-nI4gCXq7OtTzC/oxw+WT016REfuGdaBq1rOR/N17yKA=";
       };
       x86_64-linux = {
         package = "exe.linux-x64";
-        hash = "sha256-mxyV/EE2AMp1pR6+gzLXAZ3DVo/UGH9aXy30oVbvtlw=";
+        hash = "sha256-YU0YvcsSGoRMAmCzFddrc35oc0bAAbjgk/0KkyAsLWs=";
       };
     }
     .${stdenvNoCC.hostPlatform.system}
@@ -24,7 +24,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
-  version = "12.3.4";
+  version = "12.4.1";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/@pnpm/${platformSource.package}/-/${platformSource.package}-${finalAttrs.version}.tgz";


### PR DESCRIPTION
Refresh the private pnpm 12 runtime from 12.3.4 to 12.4.1 and update Nixpkgs, Home Manager, and nix-openclaw-tools. Keep bundled tool-plugin URLs on the exact revision and NAR hash recorded in flake.lock. pnpm 11.26.0, QMD 2.8.3, checkout 7.0.1, and the Nix installer 31.11.1 are already current.

Consolidate the complete Unreleased section, preserving contributor credit and all released sections. This is the final notes PR for the sweep and includes the stable-promotion repair in #143; merge #143 first. Both branches are independent of main and only this PR edits CHANGELOG.md.

Validation: Nix 2.35.2 generated the lock update in a disposable Linux environment; flake-owner validation passed. Both pnpm tarball hashes were independently calculated and checked against npm's SHA-512 integrity. The real pnpm 12.4.1 macOS executable passed offline installation, execution, and frozen-lockfile rejection with the package wrapper's settings. All 193 JavaScript contract tests and seven profile-isolation tests passed locally; the Go example has no external dependencies and builds. Independent Codex review is clean through P2. Hosted Linux/macOS package and activation proof is complete; see the exact-head evidence below.

The gateway stays on its existing release-bound lock until the fixed stable-pin workflow validates and promotes the newer OpenClaw release. No independent package version, tag, or release is introduced here.

## Verified behavior

Verified head `1307a3f5ad80724ea87e286880973983847c5db1`.

[Linux and macOS package CI passed](https://github.com/openclaw/nix-openclaw/actions/runs/34662436740). Both systems built `package-artifacts`, `module-render`, `runtime-smoke`, `platform-activation`, `runtime-plugin-packages`, `runtime-plugin-host`, and `qmd-opt-in`. These checks run the built OpenClaw CLI, start a gateway, validate health and plugin loading, and exercise the private pnpm binaries. The macOS job also ran `scripts/hm-activation-macos.sh`, including real launchd activation, skill discovery, and gateway health.

Live local proof: the actual pnpm 12.4.1 Darwin ARM64 executable passed offline local-tarball installation, package execution, byte-identical frozen-lockfile reuse, and `ERR_PNPM_OUTDATED_LOCKFILE` rejection with the repository wrapper's configuration. Both downloaded platform archives matched npm's SHA-512 integrity and the committed SHA-256 pins.

Local checks: 193 JavaScript contracts, seven Python profile-isolation tests, flake-owner validation, and the Go example build passed. Released changelog sections are byte-identical. Local and committed-branch Codex autoreviews found no actionable P0–P2 findings.

Merge #143 first so this final notes PR describes landed behavior. No tag or release was created.
