### PR TITLE
fix(hm): preserve literal runtime environment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Older repository history is available in git.
 
 ## Unreleased
 
+- Compatibility: pass runtime environment values and plugin secret-file paths literally, preserving quotes and `$` without shell expansion; resolve home paths in Nix. File loading, matching `NAME=` prefixes, `_FILE` paths, and instance overrides remain supported.
+
 - Provide Node 24 and Bash in the development shell, and run contract tests with the same pinned Node/Bash/Git toolchain on Linux and macOS.
 
 - Update the source-build Node addon headers to `node-addon-api` 8.9.2; retain the existing Node 24 runtime floor.

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ customPlugins = [
     source = "github:example/padel-cli?rev=<commit>&narHash=<narHash>";
     config = {
       env = {
-        PADEL_AUTH_FILE = "~/.secrets/padel-auth";  # where your login token lives
+        PADEL_AUTH_FILE = "/run/agenix/padel-auth";  # where your login token lives
       };
       settings = {
         default_city = "Barcelona";
@@ -805,6 +805,12 @@ programs.openclaw.config.models.providers.groq.apiKey = {
 ```
 
 That keeps nix-openclaw responsible for stable config and service wiring, keeps secrets out of the Nix store, and leaves dynamic secret-manager integration to the host layer that owns credentials and runtime side effects.
+
+Runtime environment values are literal strings: shell variables and command
+substitutions are not expanded. Values naming existing files are read at
+startup, with an optional matching `NAME=` prefix removed; variables ending in
+`_FILE` retain the file path. Use absolute secret paths or resolve home paths in
+Nix with `config.home.homeDirectory`.
 
 ### Minimal config (single instance)
 

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,7 @@
                 includeSourceOverrideChecks = true;
               };
               workspace-materializer = pkgs.callPackage ./nix/checks/openclaw-workspace-materializer.nix { };
+              runtime-environment = pkgs.callPackage ./nix/checks/openclaw-runtime-environment.nix { };
               pnpm-runtime = pkgs.callPackage ./nix/checks/openclaw-pnpm-runtime.nix {
                 inherit (packageSetStable) pnpm_11 pnpm_12;
               };
@@ -194,6 +195,7 @@
                 paths = [
                   stableChecks.config-validity
                   stableChecks.gateway-smoke
+                  stableChecks.runtime-environment
                 ];
               };
               # Runtime plugin host contract: lock consistency plus module/config

--- a/nix/checks/openclaw-runtime-environment.nix
+++ b/nix/checks/openclaw-runtime-environment.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  pkgs,
+  nodejs_24,
+}:
+let
+  helpers = import ./default-instance/helpers.nix { inherit lib pkgs; };
+  fixtures = ../tests/runtime-environment;
+  environment = import ../modules/home-manager/openclaw/environment.nix { inherit lib pkgs; };
+  guardFor =
+    value:
+    pkgs.writeShellScript "runtime-environment-guard" (
+      environment.renderGuards [
+        {
+          key = "NIX_TEST_GUARD";
+          inherit value;
+          plugin = "plugin $(touch unexpected-command)";
+          instance = "instance $value";
+        }
+      ]
+    );
+  literals = builtins.fromJSON (builtins.readFile (fixtures + "/literals.json"));
+  values = literals // {
+    NIX_TEST_FILE_VALUE = "${fixtures}/file 'quoted' $value";
+    NIX_TEST_PREFIXED = "${fixtures}/prefixed";
+    NIX_TEST_OTHER_PREFIX = "${fixtures}/other-prefix";
+    NIX_TEST_KEEP_FILE = "${fixtures}/prefixed";
+    NIX_TEST_MISSING_FILE = "/nonexistent/nix-openclaw-fixture";
+    NIX_TEST_OVERRIDE = "top-level value";
+  };
+  expected = literals // {
+    NIX_TEST_FILE_VALUE = "literal file contents $HOME $(touch unexpected-command)";
+    NIX_TEST_PREFIXED = "first=second";
+    NIX_TEST_OTHER_PREFIX = "OTHER=preserved";
+    NIX_TEST_KEEP_FILE = values.NIX_TEST_KEEP_FILE;
+    NIX_TEST_MISSING_FILE = values.NIX_TEST_MISSING_FILE;
+    NIX_TEST_OVERRIDE = "instance value";
+  };
+  evaluated = helpers.moduleEval {
+    package = pkgs.writeShellScriptBin "openclaw" (builtins.readFile (fixtures + "/cli.sh"));
+    toolNames = [ ];
+    installApp = false;
+    environment = values;
+    instances.default = {
+      appDefaults.enable = false;
+      environment.NIX_TEST_OVERRIDE = "instance value";
+    };
+  };
+  wrapper =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      builtins.head
+        evaluated.config.launchd.agents."com.steipete.openclaw.gateway".config.ProgramArguments
+    else
+      builtins.head (
+        lib.splitString " " evaluated.config.systemd.user.services.openclaw-gateway.Service.ExecStart
+      );
+in
+assert helpers.requireNoAssertionFailures "runtime environment" evaluated == "ok";
+pkgs.stdenvNoCC.mkDerivation {
+  name = "openclaw-runtime-environment";
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = true;
+  nativeBuildInputs = [ nodejs_24 ];
+  GATEWAY_WRAPPER = wrapper;
+  GUARD_VALID = guardFor values.NIX_TEST_FILE_VALUE;
+  GUARD_MISSING = guardFor "/nonexistent/file 'quoted' $value";
+  GUARD_EMPTY = guardFor "";
+  ENV_EXPORT_HELPER = ../modules/home-manager/openclaw-export-env.sh;
+  BASH_BIN = lib.getExe pkgs.bash;
+  FALSE_BIN = lib.getExe' pkgs.coreutils "false";
+  READ_FAILURE_FILE = values.NIX_TEST_FILE_VALUE;
+  EXPECTED_ENV_FILE = pkgs.writeText "runtime-environment-expected.json" (builtins.toJSON expected);
+  OPENCLAW_ENV_TEST_PRINTENV = lib.getExe' pkgs.coreutils "printenv";
+  checkPhase = "${nodejs_24}/bin/node ${fixtures}/check.mjs";
+  installPhase = "${../scripts/empty-install.sh}";
+}

--- a/nix/modules/home-manager/openclaw-check-env-file.sh
+++ b/nix/modules/home-manager/openclaw-check-env-file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+key="$1"
+file="$2"
+plugin="$3"
+instance="$4"
+if [[ -z "$file" ]]; then
+  printf 'Missing env %s for plugin %s in instance %s.\n' "$key" "$plugin" "$instance" >&2
+  exit 1
+fi
+if [[ ! -f "$file" || ! -s "$file" ]]; then
+  printf 'Required file for %s not found or empty: %s (plugin %s, instance %s).\n' "$key" "$file" "$plugin" "$instance" >&2
+  exit 1
+fi

--- a/nix/modules/home-manager/openclaw-export-env.sh
+++ b/nix/modules/home-manager/openclaw-export-env.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+# Sourced by the Nix-generated Bash gateway wrapper.
+openclawExportEnv() {
+  local key="$1" value="$2" cat_bin="$3"
+  if [[ -f "$value" && "$key" != *_FILE ]]; then
+    value=$("$cat_bin" -- "$value")
+    value="${value#"$key="}"
+  fi
+  # Set the global binding even when a user variable matches a local name.
+  declare -gx -- "$key=$value"
+}

--- a/nix/modules/home-manager/openclaw/environment.nix
+++ b/nix/modules/home-manager/openclaw/environment.nix
@@ -1,0 +1,30 @@
+{ lib, pkgs }:
+{
+  renderExports = entries: ''
+    . ${../openclaw-export-env.sh}
+    ${lib.concatMapStringsSep "\n" (
+      entry:
+      "openclawExportEnv ${
+        lib.escapeShellArgs [
+          entry.key
+          entry.value
+          (lib.getExe' pkgs.coreutils "cat")
+        ]
+      }"
+    ) entries}
+  '';
+
+  renderGuards =
+    entries:
+    lib.concatMapStringsSep "\n" (
+      entry:
+      "${pkgs.bash}/bin/bash ${../openclaw-check-env-file.sh} ${
+        lib.escapeShellArgs [
+          entry.key
+          entry.value
+          entry.plugin
+          entry.instance
+        ]
+      }"
+    ) entries;
+}

--- a/nix/modules/home-manager/openclaw/instance.nix
+++ b/nix/modules/home-manager/openclaw/instance.nix
@@ -16,6 +16,7 @@ let
     ;
   toJSONWithContext = import ../../../lib/json-with-context.nix { inherit lib; };
   runtimePlugins = import ./runtime-plugins.nix { inherit lib pkgs; };
+  environment = import ./environment.nix { inherit lib pkgs; };
 
   stripNulls =
     value:
@@ -205,30 +206,7 @@ let
           export PATH="${runtimePath}:$PATH"
         fi
 
-        ${lib.concatStringsSep "\n" (
-          map (
-            entry:
-            let
-              isFile = lib.hasSuffix "_FILE" entry.key;
-            in
-            ''
-              if [ -f "${entry.value}" ]; then
-                if ${if isFile then "true" else "false"}; then
-                  export ${entry.key}="${entry.value}"
-                else
-                  rawValue="$("${lib.getExe' pkgs.coreutils "cat"}" "${entry.value}")"
-                  if [ "''${rawValue#${entry.key}=}" != "$rawValue" ]; then
-                    export ${entry.key}="''${rawValue#${entry.key}=}"
-                  else
-                    export ${entry.key}="$rawValue"
-                  fi
-                fi
-              else
-                export ${entry.key}="${entry.value}"
-              fi
-            ''
-          ) runtimeEnvAll
-        )}
+        ${environment.renderExports runtimeEnvAll}
 
         exec "${gatewayRuntimePackage}/bin/openclaw" "$@"
       '';

--- a/nix/modules/home-manager/openclaw/plugins.nix
+++ b/nix/modules/home-manager/openclaw/plugins.nix
@@ -191,21 +191,12 @@ let
 
   pluginGuards =
     let
-      renderCheck = entry: ''
-        if [ -z "${entry.value}" ]; then
-          echo "Missing env ${entry.key} for plugin ${entry.plugin} in instance ${entry.instance}." >&2
-          exit 1
-        fi
-        if [ ! -f "${entry.value}" ] || [ ! -s "${entry.value}" ]; then
-          echo "Required file for ${entry.key} not found or empty: ${entry.value} (plugin ${entry.plugin}, instance ${entry.instance})." >&2
-          exit 1
-        fi
-      '';
+      environment = import ./environment.nix { inherit lib pkgs; };
       entriesForInstance =
         instName: map (entry: entry // { instance = instName; }) (pluginEnvFor instName);
       entries = lib.flatten (map entriesForInstance (lib.attrNames enabledInstances));
     in
-    lib.concatStringsSep "\n" (map renderCheck entries);
+    environment.renderGuards entries;
 
 in
 {

--- a/nix/tests/runtime-environment/check.mjs
+++ b/nix/tests/runtime-environment/check.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const expected = JSON.parse(fs.readFileSync(process.env.EXPECTED_ENV_FILE, "utf8"));
+const env = { ...process.env };
+for (const key of Object.keys(expected)) delete env[key];
+const result = spawnSync(process.env.GATEWAY_WRAPPER, Object.keys(expected), {
+  env, encoding: "utf8",
+});
+assert.equal(result.status, 0, result.stderr);
+assert.deepEqual(result.stdout.split("\0").slice(0, -1), Object.values(expected));
+assert.equal(fs.existsSync("unexpected-command"), false);
+console.log("generated gateway environment: literal values, file values, and overrides PASS");
+
+for (const [variable, succeeds] of [["GUARD_VALID", true], ["GUARD_MISSING", false], ["GUARD_EMPTY", false]]) {
+  const guard = spawnSync(process.env[variable], [], { env, encoding: "utf8" });
+  assert.equal(guard.status === 0, succeeds, guard.stderr);
+  if (!succeeds) {
+    assert.ok(guard.stderr.includes("plugin $(touch unexpected-command)"), guard.stderr);
+    assert.ok(guard.stderr.includes("instance $value"), guard.stderr);
+  }
+}
+const failedRead = spawnSync(process.env.BASH_BIN, ["-euo", "pipefail", "-c",
+  '. "$1"; openclawExportEnv NIX_TEST_READ_FAILURE "$2" "$3"; echo unexpected-success',
+  "env-test", process.env.ENV_EXPORT_HELPER, process.env.READ_FAILURE_FILE, process.env.FALSE_BIN,
+], { env, encoding: "utf8" });
+assert.notEqual(failedRead.status, 0);
+assert.equal(failedRead.stdout, "");
+assert.equal(fs.existsSync("unexpected-command"), false);
+console.log("generated plugin guards and failed file reads: PASS");

--- a/nix/tests/runtime-environment/cli.sh
+++ b/nix/tests/runtime-environment/cli.sh
@@ -1,0 +1,1 @@
+exec "$OPENCLAW_ENV_TEST_PRINTENV" -0 "$@"

--- a/nix/tests/runtime-environment/file 'quoted' $value
+++ b/nix/tests/runtime-environment/file 'quoted' $value
@@ -1,0 +1,1 @@
+literal file contents $HOME $(touch unexpected-command)

--- a/nix/tests/runtime-environment/literals.json
+++ b/nix/tests/runtime-environment/literals.json
@@ -1,0 +1,7 @@
+{
+  "NIX_TEST_LITERAL": "spaces \"quotes\" 'single' $HOME $(touch unexpected-command) ${literal}\nsecond line",
+  "key": "a user value for key",
+  "value": "a user value for value",
+  "rawValue": "a user value for rawValue",
+  "cat_bin": "a user value for cat_bin"
+}

--- a/nix/tests/runtime-environment/other-prefix
+++ b/nix/tests/runtime-environment/other-prefix
@@ -1,0 +1,1 @@
+OTHER=preserved

--- a/nix/tests/runtime-environment/prefixed
+++ b/nix/tests/runtime-environment/prefixed
@@ -1,0 +1,1 @@
+NIX_TEST_PREFIXED=first=second


### PR DESCRIPTION
A literal `$` or quote in `programs.openclaw.environment` or a plugin secret-file path was interpolated into generated shell source. A real Nix-built gateway-wrapper regression reproduced a startup failure (`value: unbound variable`) for a valid literal filename.

Share the environment renderer and pass shell-escaped positional arguments to small Bash helpers. Preserve file-backed values, matching `NAME=` prefixes, `_FILE` paths, instance overrides, and variables whose names match helper locals. Plugin guard messages also treat names and paths as data. Failed file reads still stop startup. The compatibility note explains that shell expansion is no longer performed.

Regression/live proof: `nix build -L .#checks.x86_64-linux.runtime-environment` fails on the old implementation and passes after the fix, executing the actual generated wrapper and guards. It covers quotes, `$`, command-substitution text, newlines, file reads, `_FILE`, overrides, local-name collisions, missing files, and read failure. No injected marker file is created. The new check is part of `runtime-smoke` on both platforms; Linux module/plugin checks pass and Darwin evaluation passes.

```text
generated gateway environment: literal values, file values, and overrides PASS
generated plugin guards and failed file reads: PASS
```

Fresh/upgrade proof also passed using actual Home Manager generations and their generated gateway wrapper (synthetic CLI verifies both secret values): first activate the base generation with `$HOME/secret`, then activate this revision with `${config.home.homeDirectory}/secret` in both the general environment and a plugin required-env path. Both start successfully, as does a fresh head generation. This exercises activation guards and the documented migration, in addition to the real gateway checks in CI.

```text
upgrade base Home Manager activation and wrapper: PASS
upgrade head Home Manager activation and wrapper: PASS
fresh head Home Manager activation and wrapper: PASS
```

Isolated Codex review is clean through P2. Final candidate: `dc306a4748b2f980966e8c568193ae014b7312a0`. [Linux/macOS CI, real gateway startup and platform activation](https://github.com/openclaw/nix-openclaw/actions/runs/34742051398).
