### PR TITLE
fix: encode generated Nix literals and validate updater modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Older repository history is available in git.
 
 ## Unreleased
 
+- Escape Nix string interpolation in generated schema and plugin metadata, including paths containing spaces; reject unknown updater arguments and keep `--check` from creating generated directories.
+
 - Provide Node 24 and Bash in the development shell, and run contract tests with the same pinned Node/Bash/Git toolchain on Linux and macOS.
 
 - Update the source-build Node addon headers to `node-addon-api` 8.9.2; retain the existing Node 24 runtime floor.

--- a/maintainers/automation.md
+++ b/maintainers/automation.md
@@ -50,3 +50,10 @@ Do not ask for a repair strategy when the desired state is clear.
 If the fix belongs in `nix-openclaw`, edit the repo, self-review the diff until there are no actionable findings, run the relevant targeted checks plus the full gate, commit directly to `main`, push directly to `main`, and verify GitHub Actions on the pushed commit.
 
 If upstream has not published public macOS app assets, call that out directly, keep the app pin on the newest public zip, keep packaging the latest stable gateway, and repair `nix-openclaw` only if it fails to do that.
+
+## Runtime plugin lock checks
+
+`node nix/scripts/update-openclaw-runtime-plugin-locks.mjs --check` compares
+regenerated artifacts without creating or changing the generated directory.
+Use no argument to write updates. Unknown or repeated flags fail before Nix
+runs; `--help` prints usage without fetching artifacts.

--- a/nix/scripts/generate-config-options.ts
+++ b/nix/scripts/generate-config-options.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { nixString as stringify } from "./nix-string.mjs";
 
 const args = process.argv.slice(2);
 const argValue = (flag: string): string | null => {
@@ -35,11 +36,6 @@ const main = async (): Promise<void> => {
     (schema.definitions as Record<string, unknown>) ||
     (schema.$defs as Record<string, unknown>) ||
     {};
-
-const stringify = (value: string): string => {
-  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
-  return `"${escaped}"`;
-};
 
 const nixAttr = (key: string): string => {
   if (/^[A-Za-z_][A-Za-z0-9_']*$/.test(key)) return key;
@@ -290,9 +286,6 @@ const objectTypeForSchema = (schema: JsonSchema, indent: string, pathSegments: s
     if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
       const valueType = typeForSchema(schema.additionalProperties as JsonSchema, indent);
       return `t.attrsOf (${valueType})`;
-    }
-    if (schema.additionalProperties === true) {
-      return "t.attrs";
     }
     return "t.attrs";
   }

--- a/nix/scripts/nix-string.mjs
+++ b/nix/scripts/nix-string.mjs
@@ -1,0 +1,6 @@
+// Nix interpolation is not JSON interpolation; encode data before emitting source.
+export function nixString(value) {
+  if (value.includes("\0")) throw new Error("Nix strings cannot contain NUL bytes");
+  const escapes = { "\\": "\\\\", '"': '\\"', "${": "\\${", "\n": "\\n", "\r": "\\r", "\t": "\\t" };
+  return `"${value.replace(/\\|"|\$\{|\n|\r|\t/g, (character) => escapes[character])}"`;
+}

--- a/nix/scripts/nix-string.test.mjs
+++ b/nix/scripts/nix-string.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { nixString, toNix } from "./runtime-plugin-locks/output.mjs";
+
+function evaluate(expression) {
+  const result = spawnSync("nix", ["--extra-experimental-features", "nix-command", "eval", "--json", "--impure", "--expr", expression], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+const literal = 'quotes " \\ tabs\t newline\n return\r unicode 🦞 ${builtins.abort "interpolation executed"}';
+test("Nix string and attribute serialization preserves data without interpolation", () => {
+  assert.equal(evaluate(nixString(literal)), literal);
+  const value = { [literal]: [literal, null, true, 42] };
+  assert.deepEqual(evaluate(toNix(value)), value);
+});
+
+test("schema descriptions, enum values and option names remain literal Nix data", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nix-schema-literal-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const directory = path.join(root, "src/config");
+  fs.mkdirSync(directory, { recursive: true });
+  const schema = { type: "object", required: [literal], properties: {
+    [literal]: { type: "string", description: literal, enum: [literal] },
+  } };
+  fs.writeFileSync(path.join(directory, "zod-schema.ts"), `export const OpenClawSchema = { toJSONSchema: () => (${JSON.stringify(schema)}) };\n`);
+  const output = path.join(root, "options.nix");
+  const generated = spawnSync(process.execPath, [path.join(import.meta.dirname, "generate-config-options.ts"), "--repo", root, "--out", output], { encoding: "utf8" });
+  assert.equal(generated.status, 0, generated.stderr);
+  assert.deepEqual(evaluate(`import (/. + ${JSON.stringify(output)}) { lib = { types.enum = values: values; mkOption = option: option; }; }`), {
+    [literal]: { description: literal, type: [literal] },
+  });
+});
+
+test("NUL is rejected rather than emitting a lossy Nix literal", () => {
+  assert.throws(() => nixString("before\0after"), /NUL/);
+});

--- a/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
+++ b/nix/scripts/openclaw-runtime-plugin-package-locks.mjs
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { nixString } from "./nix-string.mjs";
 import { isUnsupportedResolvedSource } from "./openclaw-runtime-plugin-prepare-npm.mjs";
 
 const evidenceDirName = "dependency-evidence";
@@ -172,7 +173,7 @@ export function verifyNpmPackageLockEvidenceAssets({
 // the file into the store and yields its store path as a string.
 export function renderPackageLockProbeEnv(packageLockFile) {
   if (!packageLockFile) return "";
-  const escapedPath = JSON.stringify(packageLockFile).replaceAll("${", "\\${");
+  const escapedPath = nixString(packageLockFile);
   return `OPENCLAW_RUNTIME_PLUGIN_PACKAGE_LOCK_FILE = "\${/. + ${escapedPath}}";`;
 }
 

--- a/nix/scripts/runtime-plugin-locks/nix.mjs
+++ b/nix/scripts/runtime-plugin-locks/nix.mjs
@@ -23,9 +23,9 @@ export function createNixTools({ repoRoot, sourceInfoPath, prepareNpmScriptPath 
     ];
     const expr = `
       let
-        flake = builtins.getFlake (toString ${repoRoot});
+        flake = builtins.getFlake ${nixString(repoRoot)};
         pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
-        sourceInfo = import ${sourceInfoPath};
+        sourceInfo = import (/. + ${nixString(sourceInfoPath)});
         sourceFetch = builtins.removeAttrs sourceInfo ${toNix(strippedAttrs)};
       in
         pkgs.fetchFromGitHub sourceFetch
@@ -46,7 +46,7 @@ export function createNixTools({ repoRoot, sourceInfoPath, prepareNpmScriptPath 
     }
     const expr = `
       let
-        flake = builtins.getFlake (toString ${repoRoot});
+        flake = builtins.getFlake ${nixString(repoRoot)};
         pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
       in
         pkgs.prefetch-npm-deps
@@ -94,10 +94,10 @@ export function createNixTools({ repoRoot, sourceInfoPath, prepareNpmScriptPath 
     const safeProbeName = attrNameForId(row.id);
     const expr = `
       let
-        flake = builtins.getFlake (toString ${repoRoot});
+        flake = builtins.getFlake ${nixString(repoRoot)};
         pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
         npmHooksForNode = pkgs.npmHooks.override { nodejs = pkgs.nodejs_24; };
-        prepareNpmScript = ${prepareNpmScriptPath};
+        prepareNpmScript = /. + ${nixString(prepareNpmScriptPath)};
         pluginSrc = pkgs.fetchurl {
           url = ${nixString(artifact.tarballUrl)};
           hash = ${nixString(artifact.nixHash)};

--- a/nix/scripts/runtime-plugin-locks/output.mjs
+++ b/nix/scripts/runtime-plugin-locks/output.mjs
@@ -1,10 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { stableJson } from "./io.mjs";
-
-function nixString(value) {
-  return JSON.stringify(value);
-}
+import { nixString } from "../nix-string.mjs";
 
 function nixAttrName(name) {
   return /^[A-Za-z_][A-Za-z0-9_'-]*$/.test(name) ? name : nixString(name);

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.mjs
@@ -14,7 +14,17 @@ const repoRoot = path.resolve(scriptDir, "../..");
 const sourceInfoPath = path.join(repoRoot, "nix/sources/openclaw-source.nix");
 const outputDir = path.join(repoRoot, "nix/generated/openclaw-runtime-plugins");
 const prepareNpmScriptPath = path.join(scriptDir, "openclaw-runtime-plugin-prepare-npm.mjs");
-const checkMode = process.argv.includes("--check");
+const args = process.argv.slice(2);
+const usage = "usage: update-openclaw-runtime-plugin-locks.mjs [--check]";
+if (args.length === 1 && ["--help", "-h"].includes(args[0])) {
+  console.log(usage);
+  process.exit(0);
+}
+if (args.length > 1 || (args.length === 1 && args[0] !== "--check")) {
+  console.error(usage);
+  process.exit(2);
+}
+const checkMode = args[0] === "--check";
 const { resolveOpenClawSourcePath, prepareLockedPackage, computeNpmDepsHash, probeLockMaterialization } =
   createNixTools({ repoRoot, sourceInfoPath, prepareNpmScriptPath });
 
@@ -88,8 +98,6 @@ skipped.sort((a, b) =>
   ),
 );
 
-fs.mkdirSync(outputDir, { recursive: true });
-
 const report = {
   openclawVersion: releaseVersion,
   runtimePluginVersion,
@@ -109,6 +117,8 @@ if (checkMode) {
   );
   process.exit(0);
 }
+
+fs.mkdirSync(outputDir, { recursive: true });
 
 for (const file of existingGeneratedFiles()) {
   if (!desiredFiles.has(file)) {

--- a/nix/scripts/update-openclaw-runtime-plugin-locks.test.mjs
+++ b/nix/scripts/update-openclaw-runtime-plugin-locks.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-lock-command-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const scripts = path.join(root, "nix/scripts");
+  fs.cpSync(import.meta.dirname, scripts, { recursive: true });
+  fs.mkdirSync(path.join(root, "nix/sources"));
+  fs.writeFileSync(path.join(root, "nix/sources/openclaw-source.nix"), `{
+    releaseVersion = "2026.9.4";
+    runtimePluginVersion = "2026.9.4";
+    releaseTag = "v2026.9.4";
+    rev = "fixture-revision";
+    hash = "fixture-hash";
+  }`);
+  const source = path.join(root, "source");
+  fs.mkdirSync(path.join(source, "scripts/lib"), { recursive: true });
+  fs.writeFileSync(path.join(source, "package.json"), '{"version":"2026.9.4"}');
+  for (const kind of ["channel", "plugin", "provider"]) {
+    fs.writeFileSync(path.join(source, "scripts/lib", `official-external-${kind}-catalog.json`), "[]");
+  }
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin);
+  const marker = path.join(root, "nix-invoked");
+  fs.writeFileSync(path.join(bin, "nix"), '#!/bin/sh\nprintf invoked > "$MARKER"\nprintf "%s\\n" "$SOURCE"\n', { mode: 0o755 });
+  const generated = path.join(root, "nix/generated/openclaw-runtime-plugins");
+  return {
+    marker, generated,
+    run: (...args) => spawnSync(process.execPath, [path.join(scripts, "update-openclaw-runtime-plugin-locks.mjs"), ...args], {
+      cwd: root, encoding: "utf8", env: { ...process.env, PATH: bin, MARKER: marker, SOURCE: source },
+    }),
+  };
+}
+
+for (const args of [["--chek"], ["--check", "unexpected"], ["--check", "--check"]]) {
+  test(`rejects ${args.join(" ")} before reading artifacts or writing output`, (t) => {
+    const f = fixture(t), result = f.run(...args);
+    assert.equal(result.status, 2, result.stderr);
+    assert.match(result.stderr, /usage:/i);
+    assert.equal(fs.existsSync(f.marker), false);
+    assert.equal(fs.existsSync(f.generated), false);
+  });
+}
+
+test("help does not run Nix or create output", (t) => {
+  const f = fixture(t), result = f.run("--help");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--check/);
+  assert.equal(fs.existsSync(f.marker), false);
+  assert.equal(fs.existsSync(f.generated), false);
+});
+
+test("check reports missing generated files without creating their directory", (t) => {
+  const f = fixture(t), result = f.run("--check");
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /would update/);
+  assert.equal(fs.existsSync(f.generated), false);
+});
+
+test("apply creates the generated files and a subsequent check leaves them unchanged", (t) => {
+  const f = fixture(t), apply = f.run();
+  assert.equal(apply.status, 0, apply.stderr);
+  const before = fs.readdirSync(f.generated).map((name) => [name, fs.readFileSync(path.join(f.generated, name), "utf8")]);
+  const check = f.run("--check");
+  assert.equal(check.status, 0, check.stderr);
+  assert.deepEqual(fs.readdirSync(f.generated).map((name) => [name, fs.readFileSync(path.join(f.generated, name), "utf8")]), before);
+});


### PR DESCRIPTION
Generated strings used JSON quoting as Nix source quoting, so a literal `${...}` in schema text or plugin metadata became an expression. The updater also interpreted an unknown option such as `--chek` as permission to rewrite locks, and `--check` created a missing generated directory.

Use one Nix string encoder across generators, quote checkout/source paths, and validate modes before side effects. Check mode now reports missing output without creating it. Existing generated locks remain byte-identical.

Before/after proof: real Nix evaluations failed for literal interpolation before the change and pass after it. The focused suite passes 44 tests, including actual Nix string/attribute/schema evaluation and updater nonmutation checks. A real pinned updater `--check` also succeeds from a copied checkout path containing spaces and literal `${literal}` text, reporting `90 supported, 6 skipped` and preserving generated bytes.

The literal-path proof ran this command inside the copied checkout, followed by a recursive comparison of the generated directory against the original:

```sh
nix shell --inputs-from . nixpkgs#nodejs_24 nixpkgs#unzip --command node nix/scripts/update-openclaw-runtime-plugin-locks.mjs --check
diff -r "$original/nix/generated" "$copy/nix/generated"
```

```text
nix/generated/openclaw-runtime-plugins is up to date for OpenClaw 2026.9.4: 90 supported, 6 skipped
literal checkout path and generated-byte preservation: PASS
```

Isolated Codex review is clean through P2 for the combined candidate, including the main-branch environment fix. Final head: `6b6bc65a7c1611cbd3f4268285a4aeb7c8cff9fc`. [Linux/macOS checks, gateway and activation proof](https://github.com/openclaw/nix-openclaw/actions/runs/34742867492).
