### PR TITLE
fix: make the example plugin consumable and executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Older repository history is available in git.
 
 - Update the source-build Node addon headers to `node-addon-api` 8.9.2; retain the existing Node 24 runtime floor.
 - Compatibility: stop advertising the retired Garnix cache (`cache.garnix.io` returns NXDOMAIN); builds use the operator's configured substituters and the default NixOS cache.
+- Compatibility: fix the hello-world plugin example by exporting the host-system function at the top level, locking its inputs, and installing the documented `hello-world` executable (previously emitted as `hello-world-openclaw`).
 
 ## 2026.9.4 - 2026-09-11
 

--- a/README.md
+++ b/README.md
@@ -617,11 +617,11 @@ your-plugin/
 
 ```nix
 {
-  outputs = { self, nixpkgs, ... }:
-    let
-      pkgs = import nixpkgs { system = builtins.currentSystem; };
-    in {
-      openclawPlugin = {
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs, ... }: {
+    openclawPlugin = system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
         name = "hello-world";
         skills = [ ./skills/hello-world ];
         packages = [ pkgs.hello ]; # CLI tools to install
@@ -645,7 +645,9 @@ description: Prints hello world.
 Use the `hello` CLI to print a greeting.
 ```
 
-See `examples/hello-world-plugin` for a complete working example.
+Export `openclawPlugin` at the top level, outside `eachDefaultSystem`. Use a function taking `system` when the plugin contains platform-specific packages. Commit `flake.lock` so consumers can evaluate pinned plugin sources without updating inputs.
+
+See `examples/hello-world-plugin` for a complete working example; run it with `nix run ./examples/hello-world-plugin`.
 
 ---
 
@@ -662,7 +664,7 @@ Contract to implement:
    - needs (stateDirs + requiredEnv)
 
 Example:
-openclawPlugin = {
+openclawPlugin = system: {
   name = "my-plugin";
   skills = [ ./skills/my-plugin ];
   packages = [ self.packages.${system}.default ];

--- a/docs/plugins-maintainers.md
+++ b/docs/plugins-maintainers.md
@@ -94,6 +94,8 @@ openclawPlugin = {
 };
 ```
 
+The output is top-level, not nested under a system key. It can also be a function `system: { ... }` to select packages for the consuming host. Commit the plugin flake lock for pure, pinned consumption.
+
 Host responsibilities (what the runtime guarantees):
 - Resolve plugin source; read contract.
 - Install `packages`; prepend to PATH for the gateway wrapper.
@@ -145,7 +147,7 @@ programs.openclaw.bundledPlugins.summarize.enable = true;
 Plugin contract (inside the plugin repo):
 
 ```nix
-openclawPlugin = {
+openclawPlugin = system: {
   name = "summarize";
   skills = [ ./skills/summarize ];
   packages = [ self.packages.${system}.summarize-cli ];
@@ -189,7 +191,7 @@ programs.openclaw.customPlugins = [
 Plugin contract (inside `xuezh`):
 
 ```nix
-openclawPlugin = {
+openclawPlugin = system: {
   name = "xuezh";
   skills = [ ./skills/xuezh ];
   packages = [ self.packages.${system}.default ];

--- a/examples/hello-world-plugin/flake.lock
+++ b/examples/hello-world-plugin/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-utils": "flake-utils"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/hello-world-plugin/flake.nix
+++ b/examples/hello-world-plugin/flake.nix
@@ -23,21 +23,24 @@
           version = "0.1.0";
           src = ./.;
           vendorHash = null;
+          postInstall = "${./install.sh}";
+          meta.mainProgram = "hello-world";
         };
 
         apps.default = flake-utils.lib.mkApp {
           drv = self.packages.${system}.default;
         };
-
-        openclawPlugin = {
-          name = "hello-world";
-          skills = [ ./skills/hello-world ];
-          packages = [ self.packages.${system}.default ];
-          needs = {
-            stateDirs = [ ];
-            requiredEnv = [ ];
-          };
-        };
       }
-    );
+    )
+    // {
+      openclawPlugin = system: {
+        name = "hello-world";
+        skills = [ ./skills/hello-world ];
+        packages = [ self.packages.${system}.default ];
+        needs = {
+          stateDirs = [ ];
+          requiredEnv = [ ];
+        };
+      };
+    };
 }

--- a/examples/hello-world-plugin/install.sh
+++ b/examples/hello-world-plugin/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+mv "$out/bin/hello-world-openclaw" "$out/bin/hello-world"

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,9 @@
                 openclawGateway = packageSetStable.openclaw-gateway;
                 includeRuntimePluginSmoke = true;
               };
+              example-plugin = pkgs.callPackage ./nix/checks/example-plugin.nix {
+                inherit nixpkgs flake-utils;
+              };
               runtime-plugin-locks = pkgs.callPackage ./nix/checks/openclaw-runtime-plugin-locks.nix { };
               runtime-plugin-packages = pkgs.symlinkJoin {
                 name = "openclaw-runtime-plugin-packages";
@@ -204,6 +207,7 @@
                 name = "openclaw-runtime-plugin-host";
                 paths = [
                   runtimePluginChecks.runtime-plugin-locks
+                  runtimePluginChecks.example-plugin
                   pluginChecks.plugin-instance
                   runtimePluginChecks.runtime-plugin-config-validity
                   runtimePluginChecks.runtime-plugin-gateway-smoke

--- a/nix/checks/example-plugin.nix
+++ b/nix/checks/example-plugin.nix
@@ -1,0 +1,28 @@
+{
+  pkgs,
+  nixpkgs,
+  flake-utils,
+}:
+let
+  example = (import ../../examples/hello-world-plugin/flake.nix).outputs {
+    self = example;
+    inherit nixpkgs flake-utils;
+  };
+  system = pkgs.stdenv.hostPlatform.system;
+  plugin = example.openclawPlugin system;
+  package = example.packages.${system}.default;
+in
+assert builtins.isFunction example.openclawPlugin;
+assert plugin.name == "hello-world";
+assert plugin.packages == [ package ];
+assert plugin.skills == [ ../../examples/hello-world-plugin/skills/hello-world ];
+assert example.apps.${system}.default.program == "${package}/bin/hello-world";
+pkgs.stdenvNoCC.mkDerivation {
+  name = "openclaw-example-plugin";
+  dontUnpack = true;
+  dontBuild = true;
+  doCheck = true;
+  nativeBuildInputs = plugin.packages;
+  checkPhase = "${../tests/example-plugin.sh}";
+  installPhase = "${../scripts/empty-install.sh}";
+}

--- a/nix/tests/example-plugin.sh
+++ b/nix/tests/example-plugin.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+unset OPENCLAW_USER
+hello-world > default-greeting.txt
+grep -Fx 'Hello, human. I am a very serious assistant.' default-greeting.txt
+OPENCLAW_USER='plugin fixture' hello-world > configured-greeting.txt
+grep -Fx 'Hello, plugin fixture. I am a very serious assistant.' configured-greeting.txt
+printf 'example plugin CLI and host-system contract: PASS\n'


### PR DESCRIPTION
The hello-world plugin example could neither satisfy Home Manager's plugin contract nor launch its documented CLI: `eachDefaultSystem` nested `openclawPlugin` under a system key, while Go installed `hello-world-openclaw` and the app/skill invoked `hello-world`.

Export a top-level `system: { ... }` plugin, install the documented executable, and lock the example's inputs to the repository's existing pins. Update authoring examples to avoid `builtins.currentSystem` in pure consumer evaluation. The new Nix check builds and executes the CLI and checks the package/app/plugin contract on both supported platforms.

Live proof on Linux:

```text
example plugin CLI and host-system contract: PASS
Hello, live example. I am a very serious assistant.
actual locked plugin flake consumed by Home Manager: PASS
old plugin contract and documented app entry point: reproduced failures
```

This includes `nix build .#checks.x86_64-linux.example-plugin`, a standalone locked `nix run`, and actual Home Manager consumption of its archived, hash-pinned flake. The same old flake fails the contract lookup and attempts to execute a nonexistent `bin/hello-world`. Darwin evaluation also passes. Isolated Codex review is clean through P2. Final head: `efac866d4a4f4f8dabf967cb9f429fa3671946c3`. [Linux/macOS CI and live gateway/activation proof](https://github.com/openclaw/nix-openclaw/actions/runs/34743067863).
